### PR TITLE
feat: define Config, LLMConfig, and ImagesConfig Pydantic models

### DIFF
--- a/backend/src/eduops/config.py
+++ b/backend/src/eduops/config.py
@@ -1,0 +1,25 @@
+from typing import Literal
+from pydantic import BaseModel
+
+class LLMConfig(BaseModel):
+    # Literal restricts the provider to only these specific strings
+    provider: Literal["openai", "gemini", "openrouter", "custom"]
+    api_key: str
+    model: str
+    base_url: str = "" # Defaults to an empty string if not provided
+
+class ImagesConfig(BaseModel):
+    # Defines the default list of approved images
+    approved: list[str] = [
+        "nginx:alpine", 
+        "httpd:alpine", 
+        "python:3.11-slim",
+        "alpine:3", 
+        "busybox:latest", 
+        "node:20-alpine",
+    ]
+
+class Config(BaseModel):
+    # This is the top-level model that groups the other two together
+    llm: LLMConfig
+    images: ImagesConfig = ImagesConfig()


### PR DESCRIPTION
This PR introduces the foundational Pydantic models for the application's configuration management, completing Task T007. These models strictly define the shape of the user's config.toml file, ensuring safe execution and proper LLM setup before the application runs.

Changes Included:

- Created backend/src/eduops/config.py.

- Defined the LLMConfig model to validate the provider (restricted via Literal), api_key, model, and an optional base_url.

- Defined the ImagesConfig model containing the default list of approved base images to enforce execution safety constraints.

- Defined the top-level Config model that aggregates both LLMConfig and ImagesConfig.

Resolves
Fixes #14

Acceptance Criteria Met
[x] backend/src/eduops/config.py created

[x] LLMConfig Pydantic model defined with fields: provider, api_key, model, base_url

[x] ImagesConfig Pydantic model defined with the default approved image list (nginx:alpine, httpd:alpine, python:3.11-slim, alpine:3, busybox:latest, node:20-alpine)

[x] Top-level Config model aggregates both sub-models

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added configuration system supporting multiple LLM providers with customizable API settings
  * Added container image management with preset approved images for deployments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->