### PR TITLE
feat(config): implement load_config and save_config TOML functions

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "httpx",
     "sse-starlette",
     "tomli",
+    "tomli-w",
     "pydantic"
 ]
 

--- a/backend/src/eduops/cli.py
+++ b/backend/src/eduops/cli.py
@@ -1,5 +1,3 @@
-import sys
-
 def main() -> int:
     print("eduops starting (placeholder)")
     return 0

--- a/backend/src/eduops/config.py
+++ b/backend/src/eduops/config.py
@@ -1,25 +1,85 @@
+import json
+from pathlib import Path
 from typing import Literal
+
+import tomli
 from pydantic import BaseModel
+
 
 class LLMConfig(BaseModel):
     # Literal restricts the provider to only these specific strings
     provider: Literal["openai", "gemini", "openrouter", "custom"]
     api_key: str
     model: str
-    base_url: str = "" # Defaults to an empty string if not provided
+    base_url: str = ""  # Defaults to an empty string if not provided
+
 
 class ImagesConfig(BaseModel):
     # Defines the default list of approved images
     approved: list[str] = [
-        "nginx:alpine", 
-        "httpd:alpine", 
+        "nginx:alpine",
+        "httpd:alpine",
         "python:3.11-slim",
-        "alpine:3", 
-        "busybox:latest", 
+        "alpine:3",
+        "busybox:latest",
         "node:20-alpine",
     ]
+
 
 class Config(BaseModel):
     # This is the top-level model that groups the other two together
     llm: LLMConfig
     images: ImagesConfig = ImagesConfig()
+
+
+def get_config_path() -> Path:
+    return Path.home() / ".eduops" / "config.toml"
+
+
+def load_config() -> Config | None:
+    config_path = get_config_path()
+    if not config_path.exists():
+        return None
+
+    try:
+        with open(config_path, "rb") as f:
+            data = tomli.load(f)
+    except Exception:
+        return None
+
+    if "llm" not in data:
+        return None
+
+    llm_data = data["llm"]
+    provider = llm_data.get("provider", "openai")
+    base_url = llm_data.get("base_url", "")
+
+    # Derive base_url from provider if not explicitly provided
+    if not base_url:
+        if provider == "openai":
+            base_url = ""  # Will use OpenAI client default
+        elif provider == "gemini":
+            base_url = "https://generativelanguage.googleapis.com/v1beta/openai/"
+        elif provider == "openrouter":
+            base_url = "https://openrouter.ai/api/v1"
+        llm_data["base_url"] = base_url
+
+    return Config(**data)
+
+
+def save_config(config: Config) -> None:
+    config_path = get_config_path()
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+
+    lines = [
+        "[llm]",
+        f'provider = "{config.llm.provider}"',
+        f'api_key = "{config.llm.api_key}"',
+        f'model = "{config.llm.model}"',
+        f'base_url = "{config.llm.base_url}"',
+        "",
+        "[images]",
+        f"approved = {json.dumps(config.images.approved)}",
+    ]
+
+    config_path.write_text("\n".join(lines) + "\n", encoding="utf-8")

--- a/backend/src/eduops/config.py
+++ b/backend/src/eduops/config.py
@@ -1,9 +1,10 @@
-import json
+import os
 from pathlib import Path
 from typing import Literal
 
 import tomli
-from pydantic import BaseModel
+import tomli_w
+from pydantic import BaseModel, ValidationError
 
 
 class LLMConfig(BaseModel):
@@ -52,6 +53,9 @@ def load_config() -> Config | None:
 
     llm_data = data["llm"]
     provider = llm_data.get("provider", "openai")
+    # Write the defaulted provider back so Pydantic sees it
+    if "provider" not in llm_data:
+        llm_data["provider"] = provider
     base_url = llm_data.get("base_url", "")
 
     # Derive base_url from provider if not explicitly provided
@@ -64,22 +68,27 @@ def load_config() -> Config | None:
             base_url = "https://openrouter.ai/api/v1"
         llm_data["base_url"] = base_url
 
-    return Config(**data)
+    try:
+        return Config(**data)
+    except ValidationError:
+        return None
 
 
 def save_config(config: Config) -> None:
     config_path = get_config_path()
     config_path.parent.mkdir(parents=True, exist_ok=True)
 
-    lines = [
-        "[llm]",
-        f'provider = "{config.llm.provider}"',
-        f'api_key = "{config.llm.api_key}"',
-        f'model = "{config.llm.model}"',
-        f'base_url = "{config.llm.base_url}"',
-        "",
-        "[images]",
-        f"approved = {json.dumps(config.images.approved)}",
-    ]
-
-    config_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    data = {
+        "llm": {
+            "provider": config.llm.provider,
+            "api_key": config.llm.api_key,
+            "model": config.llm.model,
+            "base_url": config.llm.base_url,
+        },
+        "images": {
+            "approved": config.images.approved,
+        },
+    }
+    config_path.write_bytes(tomli_w.dumps(data).encode("utf-8"))
+    # Restrict permissions to owner-only since the file contains the API key
+    os.chmod(config_path, 0o600)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import sqlite3
 from pathlib import Path
-from typing import AsyncGenerator
+from typing import AsyncGenerator, Iterator
 
 import httpx
 import pytest
@@ -72,7 +72,7 @@ def db_path(tmp_path: Path) -> Path:
 
 
 @pytest.fixture()
-def db_conn(db_path: Path) -> sqlite3.Connection:
+def db_conn(db_path: Path) -> Iterator[sqlite3.Connection]:
     """Return an initialised SQLite connection with the full eduops schema.
 
     The connection uses ``sqlite3.Row`` as ``row_factory`` so rows can be

--- a/specs/001-core-platform/tasks.md
+++ b/specs/001-core-platform/tasks.md
@@ -56,7 +56,7 @@ Tasks below reinforce this by: one function per task where possible, services sp
 ### Config & CLI
 
 - [x] T007 [P] Define Config, LLMConfig, and ImagesConfig Pydantic models in `backend/src/eduops/config.py` — LLMConfig (provider, api_key, model, base_url), ImagesConfig with default approved list, top-level Config aggregating both
-- [ ] T008 Implement `load_config()` and `save_config()` TOML functions in `backend/src/eduops/config.py` — read/write `~/.eduops/config.toml`, handle missing file gracefully, derive `base_url` from provider (openai → default, gemini → googleapis, openrouter → openrouter.ai, custom → user-provided)
+- [x] T008 Implement `load_config()` and `save_config()` TOML functions in `backend/src/eduops/config.py` — read/write `~/.eduops/config.toml`, handle missing file gracefully, derive `base_url` from provider (openai → default, gemini → googleapis, openrouter → openrouter.ai, custom → user-provided)
 - [ ] T018 Implement FastAPI app factory in `backend/src/eduops/app.py` — `create_app()` mounting API routers under `/api` prefix, serve frontend static files from `static/` directory with `StaticFiles(html=True)`, configure CORS for dev
 - [ ] T009 Implement CLI argument parsing and uvicorn launch in `backend/src/eduops/cli.py` — parse `eduops start` command with optional `--port` flag, launch `uvicorn` pointing to `eduops.app:app` on port 7337 (depends on T018)
 - [ ] T010 Implement interactive first-run LLM setup prompt in `backend/src/eduops/cli.py` — detect missing config, prompt for provider → API key → model, call `save_config()` to write `~/.eduops/config.toml`


### PR DESCRIPTION
Resolves #13

Implements load_config() and save_config() TOML functions in backend/src/eduops/config.py, deriving base_url from provider, and gracefully handling missing files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configuration persisted to ~/.eduops/config.toml with load/save and provider-aware defaults.
  * Multi-provider LLM support with sensible default base URLs for supported providers.

* **Tests**
  * Test fixture typing adjusted to reflect a generator/yielding connection.

* **Chores**
  * Added TOML I/O dependency.
  * Minor cleanup removing an unused import.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->