### PR TITLE
feat(app): T018 — Implement FastAPI app factory in app.py

### DIFF
--- a/backend/src/eduops/api/__init__.py
+++ b/backend/src/eduops/api/__init__.py
@@ -1,0 +1,3 @@
+from fastapi import APIRouter
+
+api_router = APIRouter()

--- a/backend/src/eduops/app.py
+++ b/backend/src/eduops/app.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
+
+from eduops.api import api_router
+
+
+def create_app() -> FastAPI:
+    """Create and configure the FastAPI application."""
+    app = FastAPI(title="eduops Core Platform")
+
+    # Configure CORS for development
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],  # Allowing all origins for dev proxy compatibility
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    # Mount API routers
+    app.include_router(api_router, prefix="/api")
+
+    # Serve static files from the 'static/' directory if it exists
+    # When installed as a package, frontend/dist is included as eduops/static
+    static_dir = Path(__file__).parent / "static"
+    if static_dir.exists() and static_dir.is_dir():
+        app.mount("/", StaticFiles(directory=str(static_dir), html=True), name="static")
+
+    return app
+
+
+# Module-level app instance for uvicorn
+app = create_app()

--- a/backend/src/eduops/app.py
+++ b/backend/src/eduops/app.py
@@ -10,11 +10,13 @@ def create_app() -> FastAPI:
     """Create and configure the FastAPI application."""
     app = FastAPI(title="eduops Core Platform")
 
-    # Configure CORS for development
+    # Configure CORS for development — allow all origins (no credentials needed;
+    # the Vite dev proxy forwards /api requests, so cookies/auth headers are not
+    # used across origins during development)
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["*"],  # Allowing all origins for dev proxy compatibility
-        allow_credentials=True,
+        allow_origins=["*"],
+        allow_credentials=False,
         allow_methods=["*"],
         allow_headers=["*"],
     )
@@ -22,8 +24,9 @@ def create_app() -> FastAPI:
     # Mount API routers
     app.include_router(api_router, prefix="/api")
 
-    # Serve static files from the 'static/' directory if it exists
-    # When installed as a package, frontend/dist is included as eduops/static
+    # Serve static files from the 'static/' directory if it exists.
+    # In packaged installs, the built frontend (frontend/dist) is expected
+    # to be placed here by the packaging configuration (see T097).
     static_dir = Path(__file__).parent / "static"
     if static_dir.exists() and static_dir.is_dir():
         app.mount("/", StaticFiles(directory=str(static_dir), html=True), name="static")

--- a/specs/001-core-platform/tasks.md
+++ b/specs/001-core-platform/tasks.md
@@ -57,7 +57,7 @@ Tasks below reinforce this by: one function per task where possible, services sp
 
 - [x] T007 [P] Define Config, LLMConfig, and ImagesConfig Pydantic models in `backend/src/eduops/config.py` — LLMConfig (provider, api_key, model, base_url), ImagesConfig with default approved list, top-level Config aggregating both
 - [x] T008 Implement `load_config()` and `save_config()` TOML functions in `backend/src/eduops/config.py` — read/write `~/.eduops/config.toml`, handle missing file gracefully, derive `base_url` from provider (openai → default, gemini → googleapis, openrouter → openrouter.ai, custom → user-provided)
-- [ ] T018 Implement FastAPI app factory in `backend/src/eduops/app.py` — `create_app()` mounting API routers under `/api` prefix, serve frontend static files from `static/` directory with `StaticFiles(html=True)`, configure CORS for dev
+- [x] T018 Implement FastAPI app factory in `backend/src/eduops/app.py` — `create_app()` mounting API routers under `/api` prefix, serve frontend static files from `static/` directory with `StaticFiles(html=True)`, configure CORS for dev
 - [ ] T009 Implement CLI argument parsing and uvicorn launch in `backend/src/eduops/cli.py` — parse `eduops start` command with optional `--port` flag, launch `uvicorn` pointing to `eduops.app:app` on port 7337 (depends on T018)
 - [ ] T010 Implement interactive first-run LLM setup prompt in `backend/src/eduops/cli.py` — detect missing config, prompt for provider → API key → model, call `save_config()` to write `~/.eduops/config.toml`
 - [ ] T011 [P] Implement Docker availability check utility in `backend/src/eduops/cli.py` — `check_docker()` calling `docker.from_env().ping()`, return clear error message if Docker daemon unreachable; call before server launch


### PR DESCRIPTION
## What Does This PR Do?

Implements the FastAPI application factory (`create_app()`) in `backend/src/eduops/app.py`, initializes the `api` package router, configures CORS for development, and wires up static file serving for the frontend build.

## Closes Issue

closes #24

## Task Reference

`T018 Implement FastAPI app factory in backend/src/eduops/app.py — create_app() mounting API routers under /api prefix, serve frontend static files from static/ directory with StaticFiles(html=True), configure CORS for dev`

## How Was This Tested?

- `ruff check src/ && ruff format src/` — all checks passed, 1 file reformatted
- `mypy src/eduops/` — Success: no issues found in 6 source files

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] New Python functions have docstrings
- [x] No hardcoded API keys, credentials, or model names
- [x] Module boundaries respected (no cross-module imports)
- [x] Corresponding task in docs/tasks.md checked off in this PR
- [ ] README or docs updated if user-facing behaviour changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Infrastructure**
  * Established core API infrastructure with modular routing
  * Configured CORS to enable frontend–backend communication
  * Enabled static file serving to host the frontend alongside the API

* **Chores**
  * Updated project task tracking (marked a task as completed)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->