### PR TITLE
feat(cli): Implement CLI argument parsing and uvicorn launch (T009)

### DIFF
--- a/backend/src/eduops/cli.py
+++ b/backend/src/eduops/cli.py
@@ -5,6 +5,7 @@ import uvicorn
 
 
 def main() -> int:
+    """Entry point for the eduops CLI."""
     parser = argparse.ArgumentParser(description="eduops CLI")
     subparsers = parser.add_subparsers(dest="command", required=True, help="Available commands")
 
@@ -22,7 +23,7 @@ def main() -> int:
         uvicorn.run("eduops.app:app", host="127.0.0.1", port=args.port)
         return 0
 
-    return 1
+    return 0
 
 
 if __name__ == "__main__":

--- a/backend/src/eduops/cli.py
+++ b/backend/src/eduops/cli.py
@@ -1,3 +1,29 @@
+import argparse
+import sys
+
+import uvicorn
+
+
 def main() -> int:
-    print("eduops starting (placeholder)")
-    return 0
+    parser = argparse.ArgumentParser(description="eduops CLI")
+    subparsers = parser.add_subparsers(dest="command", required=True, help="Available commands")
+
+    start_parser = subparsers.add_parser("start", help="Start the eduops server")
+    start_parser.add_argument(
+        "--port",
+        type=int,
+        default=7337,
+        help="Port to run the server on (default: 7337)",
+    )
+
+    args = parser.parse_args()
+
+    if args.command == "start":
+        uvicorn.run("eduops.app:app", host="127.0.0.1", port=args.port)
+        return 0
+
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/specs/001-core-platform/tasks.md
+++ b/specs/001-core-platform/tasks.md
@@ -58,7 +58,7 @@ Tasks below reinforce this by: one function per task where possible, services sp
 - [x] T007 [P] Define Config, LLMConfig, and ImagesConfig Pydantic models in `backend/src/eduops/config.py` — LLMConfig (provider, api_key, model, base_url), ImagesConfig with default approved list, top-level Config aggregating both
 - [x] T008 Implement `load_config()` and `save_config()` TOML functions in `backend/src/eduops/config.py` — read/write `~/.eduops/config.toml`, handle missing file gracefully, derive `base_url` from provider (openai → default, gemini → googleapis, openrouter → openrouter.ai, custom → user-provided)
 - [x] T018 Implement FastAPI app factory in `backend/src/eduops/app.py` — `create_app()` mounting API routers under `/api` prefix, serve frontend static files from `static/` directory with `StaticFiles(html=True)`, configure CORS for dev
-- [ ] T009 Implement CLI argument parsing and uvicorn launch in `backend/src/eduops/cli.py` — parse `eduops start` command with optional `--port` flag, launch `uvicorn` pointing to `eduops.app:app` on port 7337 (depends on T018)
+- [x] T009 Implement CLI argument parsing and uvicorn launch in `backend/src/eduops/cli.py` — parse `eduops start` command with optional `--port` flag, launch `uvicorn` pointing to `eduops.app:app` on port 7337 (depends on T018)
 - [ ] T010 Implement interactive first-run LLM setup prompt in `backend/src/eduops/cli.py` — detect missing config, prompt for provider → API key → model, call `save_config()` to write `~/.eduops/config.toml`
 - [ ] T011 [P] Implement Docker availability check utility in `backend/src/eduops/cli.py` — `check_docker()` calling `docker.from_env().ping()`, return clear error message if Docker daemon unreachable; call before server launch
 


### PR DESCRIPTION
## What Does This PR Do?

This PR implements the `eduops start` CLI command using `argparse` and launches the application via `uvicorn.run()` on the specified port.

## Closes Issue

closes #10

## Task Reference

- [x] T009 Implement CLI argument parsing and uvicorn launch in `backend/src/eduops/cli.py` — parse `eduops start` command with optional `--port` flag, launch `uvicorn` pointing to `eduops.app:app` on port 7337 (depends on T018)

## How Was This Tested?

- Tested locally by running `cd backend && uv pip install -e ".[dev]" && eduops start --help` and confirming that the help message displays correctly with the `--port` option and default `7337`.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] New Python functions have docstrings
- [x] No hardcoded API keys, credentials, or model names
- [x] Module boundaries respected (no cross-module imports)
- [x] Corresponding task in docs/tasks.md checked off in this PR
- [x] README or docs updated if user-facing behaviour changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Command-line interface now available: start the EduOps application using `eduops start`.
  * Port customization: Use the `--port` flag to specify a custom server port (default: 7337), enabling flexible deployment across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->