### PR TITLE
feat: define SetupAction discriminated union models

### DIFF
--- a/backend/src/eduops/models/scenario.py
+++ b/backend/src/eduops/models/scenario.py
@@ -1,0 +1,33 @@
+from typing import Literal
+from pydantic import BaseModel
+
+class PullImage(BaseModel):
+    action: Literal["pull_image"]
+    image: str
+
+class BuildImage(BaseModel):
+    action: Literal["build_image"]
+    tag: str
+    dockerfile_content: str
+
+class CreateNetwork(BaseModel):
+    action: Literal["create_network"]
+    name: str
+    driver: str = "bridge"
+
+class CreateVolume(BaseModel):
+    action: Literal["create_volume"]
+    name: str
+
+class RunContainer(BaseModel):
+    action: Literal["run_container"]
+    image: str
+    name: str
+    ports: dict[str, str] = {}
+    volumes: dict[str, str] = {}
+    network: str | None = None
+    env: dict[str, str] = {}
+    command: str | None = None
+    detach: bool = True
+
+SetupAction = PullImage | BuildImage | CreateNetwork | CreateVolume | RunContainer


### PR DESCRIPTION
This PR introduces the SetupAction discriminated union, fulfilling Task T014. These models map directly to the Python Docker SDK execution path, strictly enforcing Principle II (Safe Execution — No Shell Strings) from the project constitution by forcing all setup operations to be typed, parameterised objects.

Changes Included:

Created backend/src/eduops/models/scenario.py.

Implemented PullImage, BuildImage, CreateNetwork, CreateVolume, and RunContainer Pydantic models.

Configured the action field on all models as a Literal string to serve as the union discriminator.

Defined the SetupAction union type aggregating all five models.

Resolves:
Fixes #11

Acceptance Criteria Met:

[x] backend/src/eduops/models/scenario.py created

[x] PullImage defined with action: Literal["pull_image"]

[x] BuildImage defined with action: Literal["build_image"]

[x] CreateNetwork defined with action: Literal["create_network"]

[x] CreateVolume defined with action: Literal["create_volume"]

[x] RunContainer defined with action: Literal["run_container"]

[x] SetupAction discriminated union defined

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Infrastructure setup now supports defining scenarios for container image operations, network configuration, volume management, and container runtime operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->