### PR TITLE
fix: update setup action models per review

### DIFF
--- a/backend/src/eduops/models/scenario.py
+++ b/backend/src/eduops/models/scenario.py
@@ -1,32 +1,48 @@
 from typing import Annotated, Literal
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ConfigDict, field_validator
 
-class PullImage(BaseModel):
+# The strict base class that rejects hallucinated fields
+class SetupActionBase(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+class PullImage(SetupActionBase):
     action: Literal["pull_image"]
     image: str
 
-class BuildImage(BaseModel):
+    @field_validator("image")
+    @classmethod
+    def validate_approved_image(cls, value: str) -> str:
+        approved = [
+            "nginx:alpine", "httpd:alpine", "python:3.11-slim",
+            "alpine:3", "busybox:latest", "node:20-alpine"
+        ]
+        if value not in approved:
+            raise ValueError(f"Image '{value}' is not in the approved list. Use build_image for custom setups.")
+        return value
+
+class BuildImage(SetupActionBase):
     action: Literal["build_image"]
     tag: str
     dockerfile_content: str
 
-class CreateNetwork(BaseModel):
+class CreateNetwork(SetupActionBase):
     action: Literal["create_network"]
     name: str
     driver: str = "bridge"
 
-class CreateVolume(BaseModel):
+class CreateVolume(SetupActionBase):
     action: Literal["create_volume"]
     name: str
 
-class RunContainer(BaseModel):
+class RunContainer(SetupActionBase):
     action: Literal["run_container"]
     image: str
     name: str
-    ports: dict[str, str] = {}
-    volumes: dict[str, str] = {}
+    # Fixed mutable defaults
+    ports: dict[str, str] = Field(default_factory=dict)
+    volumes: dict[str, str] = Field(default_factory=dict)
     network: str | None = None
-    env: dict[str, str] = {}
+    env: dict[str, str] = Field(default_factory=dict)
     command: list[str] | None = None
     detach: bool = True
 

--- a/backend/src/eduops/models/scenario.py
+++ b/backend/src/eduops/models/scenario.py
@@ -1,0 +1,36 @@
+from typing import Annotated, Literal
+from pydantic import BaseModel, Field
+
+class PullImage(BaseModel):
+    action: Literal["pull_image"]
+    image: str
+
+class BuildImage(BaseModel):
+    action: Literal["build_image"]
+    tag: str
+    dockerfile_content: str
+
+class CreateNetwork(BaseModel):
+    action: Literal["create_network"]
+    name: str
+    driver: str = "bridge"
+
+class CreateVolume(BaseModel):
+    action: Literal["create_volume"]
+    name: str
+
+class RunContainer(BaseModel):
+    action: Literal["run_container"]
+    image: str
+    name: str
+    ports: dict[str, str] = {}
+    volumes: dict[str, str] = {}
+    network: str | None = None
+    env: dict[str, str] = {}
+    command: list[str] | None = None
+    detach: bool = True
+
+SetupAction = Annotated[
+    PullImage | BuildImage | CreateNetwork | CreateVolume | RunContainer,
+    Field(discriminator="action")
+]


### PR DESCRIPTION
This PR re-introduces the SetupAction models (originally from T014) with fixes applied from the CodeRabbit review to ensure strict adherence to Pydantic best practices and execution safety constraints.

Updated RunContainer.command to list[str] | None to enforce an argv shape and prevent shell string injection vulnerabilities.

Wrapped the SetupAction union in Annotated[..., Field(discriminator="action")] to properly configure it as a strict Pydantic discriminated union.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive setup wizard and CLI start command for configuring and launching the app
  * REST API with development-friendly CORS and optional static frontend serving
  * Container/Docker scenario schemas for defining automated setup steps
  * Expanded frontend types for sessions, health reporting, chat/messages, and automated checks

* **Chores**
  * Updated task completion statuses in project documentation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->