### PR TITLE
fix: implement strict setup action models per review

### DIFF
--- a/backend/src/eduops/models/scenario.py
+++ b/backend/src/eduops/models/scenario.py
@@ -1,0 +1,52 @@
+from typing import Annotated, Literal
+from pydantic import BaseModel, Field, ConfigDict, field_validator
+
+# The strict base class that rejects hallucinated fields
+class SetupActionBase(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+class PullImage(SetupActionBase):
+    action: Literal["pull_image"]
+    image: str
+
+    @field_validator("image")
+    @classmethod
+    def validate_approved_image(cls, value: str) -> str:
+        approved = [
+            "nginx:alpine", "httpd:alpine", "python:3.11-slim",
+            "alpine:3", "busybox:latest", "node:20-alpine"
+        ]
+        if value not in approved:
+            raise ValueError(f"Image '{value}' is not in the approved list. Use build_image for custom setups.")
+        return value
+
+class BuildImage(SetupActionBase):
+    action: Literal["build_image"]
+    tag: str
+    dockerfile_content: str
+
+class CreateNetwork(SetupActionBase):
+    action: Literal["create_network"]
+    name: str
+    driver: str = "bridge"
+
+class CreateVolume(SetupActionBase):
+    action: Literal["create_volume"]
+    name: str
+
+class RunContainer(SetupActionBase):
+    action: Literal["run_container"]
+    image: str
+    name: str
+    # Fixed mutable defaults
+    ports: dict[str, str] = Field(default_factory=dict)
+    volumes: dict[str, str] = Field(default_factory=dict)
+    network: str | None = None
+    env: dict[str, str] = Field(default_factory=dict)
+    command: list[str] | None = None
+    detach: bool = True
+
+SetupAction = Annotated[
+    PullImage | BuildImage | CreateNetwork | CreateVolume | RunContainer,
+    Field(discriminator="action")
+]


### PR DESCRIPTION
This PR cleanly implements the SetupAction models for Task T014, replacing the previous PR to resolve Git history conflicts. It fully integrates all CodeRabbit review feedback to ensure strict adherence to Pydantic best practices and our execution safety constraints.

Changes Included:

Strict Base Model: Created SetupActionBase with ConfigDict(extra="forbid") to ensure Pydantic aggressively rejects any hallucinated fields from the LLM.

Approved Image Validation: Added @field_validator to PullImage.image to strictly enforce the allowed image list (nginx:alpine, etc.) at the schema boundary.

Instance Isolation: Replaced all mutable default dictionaries ({}) in RunContainer with Field(default_factory=dict) to prevent shared state across instances.

Shell Injection Prevention: Enforced command: list[str] | None in RunContainer to guarantee an argv shape.

Deterministic Union: Wrapped the final SetupAction union in Annotated[..., Field(discriminator="action")] to ensure proper tagged-union validation.

Resolves:
Fixes #11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced scenario setup: add validated image pulling, image building, network creation, and volume creation.
  * Improved container run support with sensible defaults (ports/volumes/env isolation, optional network/command, detached runs).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->