### PR TITLE
feat(cli): implement docker availability check utility (T011)

### DIFF
--- a/backend/src/eduops/cli.py
+++ b/backend/src/eduops/cli.py
@@ -84,9 +84,16 @@ def check_docker() -> bool:
     Returns:
         bool: True if Docker is reachable, False otherwise.
     """
+    client = None
     try:
-        client = docker.from_env()
-        return client.ping()
+        client = docker.from_env(timeout=5)
+        if not client.ping():
+            print(
+                "Error: Docker daemon is unreachable. Please ensure Docker is installed and running.",
+                file=sys.stderr,
+            )
+            return False
+        return True
     except DockerException as e:
         print(
             "Error: Docker daemon is unreachable. Please ensure Docker is installed and running.\n"
@@ -94,6 +101,9 @@ def check_docker() -> bool:
             file=sys.stderr,
         )
         return False
+    finally:
+        if client is not None:
+            client.close()
 
 
 def main() -> int:

--- a/backend/src/eduops/cli.py
+++ b/backend/src/eduops/cli.py
@@ -3,7 +3,9 @@ import getpass
 import sys
 from typing import Literal, cast
 
+import docker  # type: ignore
 import uvicorn
+from docker.errors import DockerException  # type: ignore
 
 from eduops.config import Config, LLMConfig, load_config, save_config, get_config_path
 
@@ -76,6 +78,24 @@ def interactive_setup() -> None:
     print("\nConfiguration saved successfully to ~/.eduops/config.toml!\n")
 
 
+def check_docker() -> bool:
+    """Check if the Docker daemon is reachable.
+
+    Returns:
+        bool: True if Docker is reachable, False otherwise.
+    """
+    try:
+        client = docker.from_env()
+        return client.ping()
+    except DockerException as e:
+        print(
+            "Error: Docker daemon is unreachable. Please ensure Docker is installed and running.\n"
+            f"Details: {e}",
+            file=sys.stderr,
+        )
+        return False
+
+
 def main() -> int:
     """Entry point for the eduops CLI."""
     parser = argparse.ArgumentParser(description="eduops CLI")
@@ -94,6 +114,9 @@ def main() -> int:
     args = parser.parse_args()
 
     if args.command == "start":
+        if not check_docker():
+            return 1
+
         config_path = get_config_path()
         if not config_path.exists():
             try:

--- a/specs/001-core-platform/tasks.md
+++ b/specs/001-core-platform/tasks.md
@@ -60,7 +60,7 @@ Tasks below reinforce this by: one function per task where possible, services sp
 - [x] T018 Implement FastAPI app factory in `backend/src/eduops/app.py` — `create_app()` mounting API routers under `/api` prefix, serve frontend static files from `static/` directory with `StaticFiles(html=True)`, configure CORS for dev
 - [x] T009 Implement CLI argument parsing and uvicorn launch in `backend/src/eduops/cli.py` — parse `eduops start` command with optional `--port` flag, launch `uvicorn` pointing to `eduops.app:app` on port 7337 (depends on T018)
 - [ ] T010 Implement interactive first-run LLM setup prompt in `backend/src/eduops/cli.py` — detect missing config, prompt for provider → API key → model, call `save_config()` to write `~/.eduops/config.toml`
-- [ ] T011 [P] Implement Docker availability check utility in `backend/src/eduops/cli.py` — `check_docker()` calling `docker.from_env().ping()`, return clear error message if Docker daemon unreachable; call before server launch
+- [x] T011 [P] Implement Docker availability check utility in `backend/src/eduops/cli.py` — `check_docker()` calling `docker.from_env().ping()`, return clear error message if Docker daemon unreachable; call before server launch
 
 ### Database
 


### PR DESCRIPTION
Closes #15

Implements the Docker availability check utility defined in task T011.

- Added `check_docker()` to `backend/src/eduops/cli.py` which uses `docker.from_env().ping()` to ensure the Docker daemon is reachable.
- Wired `check_docker()` into the `main()` function under the `start` command to fail fast and display a clear, descriptive error if Docker is unavailable.
- Passed `ruff`, `mypy` (added type ignores for `docker-py` missing stubs) and `pytest`.
- Marked T011 as completed in `tasks.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server startup now validates Docker is reachable. If the Docker daemon cannot be contacted, the application will print an error and halt startup to prevent running in an unsupported environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->