### PR TITLE
feat(db): T012 — Implement SQLite schema DDL and init_db()

### DIFF
--- a/backend/src/eduops/db.py
+++ b/backend/src/eduops/db.py
@@ -1,0 +1,88 @@
+"""
+backend/src/eduops/db.py
+
+SQLite schema DDL and database initialisation.
+
+Constitution constraint: no ORM — raw sqlite3 only.
+Schema defined in specs/001-core-platform/data-model.md.
+"""
+
+import sqlite3
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Schema DDL
+# ---------------------------------------------------------------------------
+
+_DDL = """\
+CREATE TABLE IF NOT EXISTS scenarios (
+    id          TEXT PRIMARY KEY,
+    title       TEXT NOT NULL,
+    description TEXT NOT NULL,
+    difficulty  TEXT NOT NULL CHECK(difficulty IN ('easy', 'medium', 'hard')),
+    tags        TEXT NOT NULL,
+    source      TEXT NOT NULL CHECK(source IN ('bundled', 'generated')),
+    schema_json TEXT NOT NULL,
+    embedding   BLOB NOT NULL,
+    created_at  TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_scenarios_source     ON scenarios(source);
+CREATE INDEX IF NOT EXISTS idx_scenarios_difficulty ON scenarios(difficulty);
+
+CREATE TABLE IF NOT EXISTS sessions (
+    id             TEXT PRIMARY KEY,
+    scenario_id    TEXT NOT NULL REFERENCES scenarios(id),
+    status         TEXT NOT NULL CHECK(status IN ('active', 'completed', 'abandoned')),
+    workspace_path TEXT NOT NULL,
+    started_at     TEXT NOT NULL,
+    completed_at   TEXT,
+    review_text    TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_sessions_status      ON sessions(status);
+CREATE INDEX IF NOT EXISTS idx_sessions_scenario_id ON sessions(scenario_id);
+
+CREATE TABLE IF NOT EXISTS hint_log (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT    NOT NULL REFERENCES sessions(id),
+    hint_index INTEGER NOT NULL,
+    shown_at   TEXT    NOT NULL,
+    UNIQUE(session_id, hint_index)
+);
+
+CREATE TABLE IF NOT EXISTS chat_log (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL REFERENCES sessions(id),
+    role       TEXT NOT NULL CHECK(role IN ('user', 'assistant')),
+    content    TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_chat_log_session      ON chat_log(session_id);
+CREATE INDEX IF NOT EXISTS idx_chat_log_session_time ON chat_log(session_id, created_at);
+"""
+
+# Default database path: ~/.eduops/eduops.db
+_DEFAULT_DB_PATH = Path.home() / ".eduops" / "eduops.db"
+
+
+def init_db(path: Path | None = None) -> None:
+    """Create all four tables and their indexes if they do not already exist.
+
+    Idempotent — safe to call on every startup.
+
+    Args:
+        path: Absolute path to the SQLite database file.  Defaults to
+              ``~/.eduops/eduops.db``.  Parent directories are created
+              automatically.
+    """
+    db_path = path or _DEFAULT_DB_PATH
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.executescript(_DDL)
+        conn.commit()
+    finally:
+        conn.close()

--- a/backend/src/eduops/db.py
+++ b/backend/src/eduops/db.py
@@ -67,20 +67,39 @@ CREATE INDEX IF NOT EXISTS idx_chat_log_session_time ON chat_log(session_id, cre
 _DEFAULT_DB_PATH = Path.home() / ".eduops" / "eduops.db"
 
 
+def _connect(db_path: Path) -> sqlite3.Connection:
+    """Open a SQLite connection with foreign-key enforcement enabled.
+
+    SQLite does not enforce REFERENCES constraints unless
+    ``PRAGMA foreign_keys = ON`` is set for every connection.  This
+    helper ensures that constraint is always active.
+
+    Args:
+        db_path: Absolute, resolved path to the database file.
+
+    Returns:
+        An open ``sqlite3.Connection`` with foreign keys enabled.
+    """
+    conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA foreign_keys = ON;")
+    return conn
+
+
 def init_db(path: Path | None = None) -> None:
     """Create all four tables and their indexes if they do not already exist.
 
     Idempotent — safe to call on every startup.
 
     Args:
-        path: Absolute path to the SQLite database file.  Defaults to
+        path: Path to the SQLite database file.  ``~`` is expanded and the
+              result is resolved to an absolute path.  Defaults to
               ``~/.eduops/eduops.db``.  Parent directories are created
               automatically.
     """
-    db_path = path or _DEFAULT_DB_PATH
+    db_path = Path(path or _DEFAULT_DB_PATH).expanduser().resolve()
     db_path.parent.mkdir(parents=True, exist_ok=True)
 
-    conn = sqlite3.connect(db_path)
+    conn = _connect(db_path)
     try:
         conn.executescript(_DDL)
         conn.commit()

--- a/specs/001-core-platform/tasks.md
+++ b/specs/001-core-platform/tasks.md
@@ -64,7 +64,7 @@ Tasks below reinforce this by: one function per task where possible, services sp
 
 ### Database
 
-- [ ] T012 [P] Implement SQLite schema DDL and `init_db()` in `backend/src/eduops/db.py` — create four tables (scenarios, sessions, hint_log, chat_log) per schema from data-model.md, ensure idempotent with IF NOT EXISTS, create all indexes
+- [x] T012 [P] Implement SQLite schema DDL and `init_db()` in `backend/src/eduops/db.py` — create four tables (scenarios, sessions, hint_log, chat_log) per schema from data-model.md, ensure idempotent with IF NOT EXISTS, create all indexes
 - [ ] T013 Implement SQLite query helpers in `backend/src/eduops/db.py` — `get_db(path)` context manager yielding connection with row_factory, `execute()`, `fetchone()`, `fetchall()` parameterised query wrappers
 
 ### Domain Models


### PR DESCRIPTION
## Summary

Closes #19

Implements `init_db()` in `backend/src/eduops/db.py` — creates all four tables and their indexes using `IF NOT EXISTS` DDL, exactly as specified in `specs/001-core-platform/data-model.md`.

## Changes

| File | What |
|------|------|
| `backend/src/eduops/db.py` | New — full schema DDL + `init_db(path?)` |

## Schema

Four tables created:

- **`scenarios`** — scenario catalogue; `difficulty` and `source` CHECK constraints; indexes on `source` and `difficulty`
- **`sessions`** — one row per attempt; `status` CHECK constraint (`active`/`completed`/`abandoned`); FK → `scenarios.id`; indexes on `status` and `scenario_id`
- **`hint_log`** — consumed hint indices per session; `UNIQUE(session_id, hint_index)` prevents repeats; FK → `sessions.id`
- **`chat_log`** — full message history; `role` CHECK constraint; FK → `sessions.id`; indexes on `session_id` and `(session_id, created_at)`

Six named indexes total: `idx_scenarios_source`, `idx_scenarios_difficulty`, `idx_sessions_status`, `idx_sessions_scenario_id`, `idx_chat_log_session`, `idx_chat_log_session_time`.

## Acceptance Criteria

- [x] `backend/src/eduops/db.py` created
- [x] `init_db()` creates all four tables: `scenarios`, `sessions`, `hint_log`, `chat_log`
- [x] Schema matches `specs/001-core-platform/data-model.md`
- [x] Uses `IF NOT EXISTS` for full idempotency (verified by calling twice)
- [x] All six indexes created per data-model.md

## Notes

- No ORM — raw `sqlite3` only (constitution constraint)
- Default DB path: `~/.eduops/eduops.db`; parent dirs created automatically
- `init_db()` accepts an optional `path` argument for testing isolation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added local database infrastructure to store educational scenarios, sessions, hint logs, and chat interactions, with durable local storage and safe, repeatable initialization.

* **Documentation**
  * Updated project task tracker to mark the related database task as completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->