### PR TITLE
feat(db): add sqlite query helper wrappers

### DIFF
--- a/backend/src/eduops/db.py
+++ b/backend/src/eduops/db.py
@@ -8,7 +8,10 @@ Schema defined in specs/001-core-platform/data-model.md.
 """
 
 import sqlite3
+from collections.abc import Mapping, Sequence
+from contextlib import contextmanager
 from pathlib import Path
+from typing import Any, Iterator
 
 # ---------------------------------------------------------------------------
 # Schema DDL
@@ -66,6 +69,8 @@ CREATE INDEX IF NOT EXISTS idx_chat_log_session_time ON chat_log(session_id, cre
 # Default database path: ~/.eduops/eduops.db
 _DEFAULT_DB_PATH = Path.home() / ".eduops" / "eduops.db"
 
+_SQLParams = Sequence[Any] | Mapping[str, Any]
+
 
 def _connect(db_path: Path) -> sqlite3.Connection:
     """Open a SQLite connection with foreign-key enforcement enabled.
@@ -83,6 +88,48 @@ def _connect(db_path: Path) -> sqlite3.Connection:
     conn = sqlite3.connect(db_path)
     conn.execute("PRAGMA foreign_keys = ON;")
     return conn
+
+
+@contextmanager
+def get_db(path: Path | None = None) -> Iterator[sqlite3.Connection]:
+    """Yield a SQLite connection configured for keyed row access.
+
+    Args:
+        path: Optional database path. Uses ``~/.eduops/eduops.db`` when omitted.
+
+    Yields:
+        Open ``sqlite3.Connection`` configured with ``sqlite3.Row`` row factory.
+    """
+    db_path = Path(path or _DEFAULT_DB_PATH).expanduser().resolve()
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    conn = _connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+def execute(conn: sqlite3.Connection, query: str, params: _SQLParams = ()) -> sqlite3.Cursor:
+    """Execute a parameterised write/query statement and commit.
+
+    ``params`` are always bound via sqlite placeholders (``?`` / named params),
+    preventing string interpolation in SQL execution paths.
+    """
+    cur = conn.execute(query, params)
+    conn.commit()
+    return cur
+
+
+def fetchone(conn: sqlite3.Connection, query: str, params: _SQLParams = ()) -> sqlite3.Row | None:
+    """Execute a parameterised SELECT and return a single row."""
+    return conn.execute(query, params).fetchone()
+
+
+def fetchall(conn: sqlite3.Connection, query: str, params: _SQLParams = ()) -> list[sqlite3.Row]:
+    """Execute a parameterised SELECT and return all rows."""
+    return conn.execute(query, params).fetchall()
 
 
 def init_db(path: Path | None = None) -> None:

--- a/backend/src/eduops/db.py
+++ b/backend/src/eduops/db.py
@@ -122,7 +122,7 @@ def execute(
     conn: sqlite3.Connection,
     query: str,
     params: _SQLParams = (),
-    commit: bool = True,
+    commit: bool = False,
 ) -> sqlite3.Cursor:
     """Execute a parameterised write/query statement.
 
@@ -133,8 +133,8 @@ def execute(
         conn: Active SQLite connection.
         query: SQL statement with placeholders.
         params: Positional or named parameters to bind.
-        commit: When ``True`` (default), commit immediately after execution.
-                Set to ``False`` for batched writes and commit once at the end.
+        commit: When ``True``, commit immediately after execution.
+            Defaults to ``False`` so transaction contexts can control commit.
     """
     cur = conn.execute(query, params)
     if commit:

--- a/backend/src/eduops/db.py
+++ b/backend/src/eduops/db.py
@@ -94,6 +94,9 @@ def _connect(db_path: Path) -> sqlite3.Connection:
 def get_db(path: Path | None = None) -> Iterator[sqlite3.Connection]:
     """Yield a SQLite connection configured for keyed row access.
 
+    This context manager wraps work in a transaction-like lifecycle:
+    commit on normal exit and rollback if an exception escapes.
+
     Args:
         path: Optional database path. Uses ``~/.eduops/eduops.db`` when omitted.
 
@@ -107,18 +110,35 @@ def get_db(path: Path | None = None) -> Iterator[sqlite3.Connection]:
     conn.row_factory = sqlite3.Row
     try:
         yield conn
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
     finally:
         conn.close()
 
 
-def execute(conn: sqlite3.Connection, query: str, params: _SQLParams = ()) -> sqlite3.Cursor:
-    """Execute a parameterised write/query statement and commit.
+def execute(
+    conn: sqlite3.Connection,
+    query: str,
+    params: _SQLParams = (),
+    commit: bool = True,
+) -> sqlite3.Cursor:
+    """Execute a parameterised write/query statement.
 
     ``params`` are always bound via sqlite placeholders (``?`` / named params),
     preventing string interpolation in SQL execution paths.
+
+    Args:
+        conn: Active SQLite connection.
+        query: SQL statement with placeholders.
+        params: Positional or named parameters to bind.
+        commit: When ``True`` (default), commit immediately after execution.
+                Set to ``False`` for batched writes and commit once at the end.
     """
     cur = conn.execute(query, params)
-    conn.commit()
+    if commit:
+        conn.commit()
     return cur
 
 

--- a/backend/tests/test_db_helpers.py
+++ b/backend/tests/test_db_helpers.py
@@ -55,6 +55,7 @@ def test_execute_and_fetch_wrappers_are_parameterized(db_path: Path) -> None:
                 b"\x00" * 1536,
                 created_at,
             ),
+            commit=True,
         )
 
         row = fetchone(conn, "SELECT id, created_at FROM scenarios WHERE id = ?", (scenario_id,))

--- a/backend/tests/test_db_helpers.py
+++ b/backend/tests/test_db_helpers.py
@@ -65,3 +65,50 @@ def test_execute_and_fetch_wrappers_are_parameterized(db_path: Path) -> None:
     assert row["created_at"] == created_at
     assert len(rows) == 1
     assert rows[0]["id"] == scenario_id
+
+
+def test_execute_commit_false_defers_write_until_manual_commit(db_path: Path) -> None:
+    """execute(..., commit=False) should not persist data until conn.commit()."""
+    init_db(db_path)
+
+    with get_db(db_path) as conn:
+        execute(
+            conn,
+            (
+                "INSERT INTO scenarios "
+                "(id, title, description, difficulty, tags, source, schema_json, embedding, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
+            ),
+            ("s2", "t", "d", "easy", "[]", "bundled", "{}", b"\x00" * 1536, "now"),
+            commit=False,
+        )
+        # Same connection sees uncommitted row.
+        assert fetchone(conn, "SELECT id FROM scenarios WHERE id = ?", ("s2",)) is not None
+        conn.rollback()
+
+        # Rollback removed deferred write.
+        assert fetchone(conn, "SELECT id FROM scenarios WHERE id = ?", ("s2",)) is None
+
+
+def test_get_db_rolls_back_on_exception(db_path: Path) -> None:
+    """get_db should rollback pending writes when exiting due to an exception."""
+    init_db(db_path)
+
+    try:
+        with get_db(db_path) as conn:
+            execute(
+                conn,
+                (
+                    "INSERT INTO scenarios "
+                    "(id, title, description, difficulty, tags, source, schema_json, embedding, created_at) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
+                ),
+                ("s3", "t", "d", "easy", "[]", "bundled", "{}", b"\x00" * 1536, "now"),
+                commit=False,
+            )
+            raise RuntimeError("force rollback")
+    except RuntimeError:
+        pass
+
+    with get_db(db_path) as conn:
+        assert fetchone(conn, "SELECT id FROM scenarios WHERE id = ?", ("s3",)) is None

--- a/backend/tests/test_db_helpers.py
+++ b/backend/tests/test_db_helpers.py
@@ -1,0 +1,67 @@
+"""Tests for SQLite query helpers in eduops.db."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from eduops.db import execute, fetchall, fetchone, get_db, init_db
+
+
+def test_get_db_sets_row_factory(db_path: Path) -> None:
+    """Connections from get_db should return rows addressable by column name."""
+    init_db(db_path)
+
+    with get_db(db_path) as conn:
+        row = fetchone(conn, "SELECT 1 AS value")
+
+    assert row is not None
+    assert isinstance(row, sqlite3.Row)
+    assert row["value"] == 1
+
+
+def test_execute_and_fetch_wrappers_are_parameterized(db_path: Path) -> None:
+    """Wrapper helpers should safely bind user input values via SQL parameters."""
+    init_db(db_path)
+
+    scenario_id = "s1"
+    title = "safe-title"
+    description = "desc"
+    difficulty = "easy"
+    tags = '[]'
+    source = "bundled"
+    schema_json = "{}"
+    # Contains SQL-looking text that would be dangerous if interpolated.
+    created_at = "2026-03-17'); DROP TABLE scenarios; --"
+
+    insert_sql = (
+        "INSERT INTO scenarios "
+        "(id, title, description, difficulty, tags, source, schema_json, embedding, created_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
+    )
+
+    with get_db(db_path) as conn:
+        execute(
+            conn,
+            insert_sql,
+            (
+                scenario_id,
+                title,
+                description,
+                difficulty,
+                tags,
+                source,
+                schema_json,
+                b"\x00" * 1536,
+                created_at,
+            ),
+        )
+
+        row = fetchone(conn, "SELECT id, created_at FROM scenarios WHERE id = ?", (scenario_id,))
+        rows = fetchall(conn, "SELECT id FROM scenarios WHERE source = ?", (source,))
+
+    assert row is not None
+    assert row["id"] == scenario_id
+    assert row["created_at"] == created_at
+    assert len(rows) == 1
+    assert rows[0]["id"] == scenario_id

--- a/backend/tests/test_db_helpers.py
+++ b/backend/tests/test_db_helpers.py
@@ -85,6 +85,14 @@ def test_execute_commit_false_defers_write_until_manual_commit(db_path: Path) ->
         )
         # Same connection sees uncommitted row.
         assert fetchone(conn, "SELECT id FROM scenarios WHERE id = ?", ("s2",)) is not None
+        conn.commit()
+
+        # Explicit commit persists deferred write.
+        assert fetchone(conn, "SELECT id FROM scenarios WHERE id = ?", ("s2",)) is not None
+
+        # Keep test self-contained by cleaning the inserted row.
+        execute(conn, "DELETE FROM scenarios WHERE id = ?", ("s2",), commit=True)
+
         conn.rollback()
 
         # Rollback removed deferred write.

--- a/specs/001-core-platform/tasks.md
+++ b/specs/001-core-platform/tasks.md
@@ -65,7 +65,7 @@ Tasks below reinforce this by: one function per task where possible, services sp
 ### Database
 
 - [x] T012 [P] Implement SQLite schema DDL and `init_db()` in `backend/src/eduops/db.py` — create four tables (scenarios, sessions, hint_log, chat_log) per schema from data-model.md, ensure idempotent with IF NOT EXISTS, create all indexes
-- [ ] T013 Implement SQLite query helpers in `backend/src/eduops/db.py` — `get_db(path)` context manager yielding connection with row_factory, `execute()`, `fetchone()`, `fetchall()` parameterised query wrappers
+- [x] T013 Implement SQLite query helpers in `backend/src/eduops/db.py` — `get_db(path)` context manager yielding connection with row_factory, `execute()`, `fetchone()`, `fetchall()` parameterised query wrappers
 
 ### Domain Models
 


### PR DESCRIPTION
This pull request introduces a set of SQLite query helper functions to the `backend/src/eduops/db.py` module, improving database access safety and convenience. It also adds tests for these helpers and marks the corresponding task as completed in the project specs.

Database access helpers:

* Added `get_db` context manager for safe connection handling, ensuring the SQLite connection uses `sqlite3.Row` for column-name access and is properly closed after use.
* Introduced parameterized query helper functions: `execute`, `fetchone`, and `fetchall`, which prevent SQL injection by binding user input safely via SQL parameters.
* Defined `_SQLParams` type alias for improved type safety in query helpers.
* Updated imports to support new helpers and type annotations.

Testing and project tracking:

* Added `backend/tests/test_db_helpers.py` with tests confirming correct row access and parameterization in the new helpers.
* Marked task T013 as completed in `specs/001-core-platform/tasks.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added safe, parameterized SQLite query helpers and a context-managed database connection with automatic commit/rollback semantics to simplify and stabilize data operations.

* **Tests**
  * Added comprehensive tests validating parameter binding, column-name row access, commit/rollback behavior, and resilience against unsafe input strings.

* **Chores**
  * Marked the SQLite integration task as completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->