### PR TITLE
feat: implement health check api endpoint

### DIFF
--- a/backend/src/eduops/api/__init__.py
+++ b/backend/src/eduops/api/__init__.py
@@ -1,3 +1,7 @@
 from fastapi import APIRouter
+from eduops.api.health import router as health_router
 
 api_router = APIRouter()
+
+# Mount the health router
+api_router.include_router(health_router, tags=["health"])

--- a/backend/src/eduops/api/health.py
+++ b/backend/src/eduops/api/health.py
@@ -1,0 +1,26 @@
+from fastapi import APIRouter
+from pydantic import BaseModel, ConfigDict
+
+router = APIRouter()
+
+# Define the exact shape required by the API contract
+class HealthResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True)
+    
+    docker_status: str
+    llm_configured: bool
+    active_session_id: str | None
+    scenario_count: int
+
+@router.get("/health", response_model=HealthResponse)
+async def check_health() -> HealthResponse:
+    """
+    Get the health status of the EduOps backend dependencies.
+    """
+    # Placeholder values: These will be wired up to actual system checks in future tasks
+    return HealthResponse(
+        docker_status="connected",
+        llm_configured=True,
+        active_session_id=None,
+        scenario_count=0
+    )


### PR DESCRIPTION
### Description
This PR implements the `GET /api/health` endpoint to fulfill Task T020. 

**Changes Included:**
* Created `backend/src/eduops/api/health.py` with an `APIRouter`.
* Defined a strict `HealthResponse` Pydantic model enforcing the exact fields required by `contracts/api.md` (`docker_status`, `llm_configured`, `active_session_id`, `scenario_count`).
* Implemented the `GET /health` route with placeholder data, ready to be wired into the live system checks in Phase 3.
* Registered the health router in `backend/src/eduops/api/__init__.py` to expose it on the main `/api` prefix.

### Resolves
Fixes #23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a health check endpoint that provides system status information, including Docker connectivity, LLM configuration status, active session details, and scenario count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->