### PR TITLE
feat: implement load_bundled_scenarios for catalogue service

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -34,3 +34,4 @@ eduops = "eduops.cli:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/eduops"]
+include = ["/src/eduops/scenarios"]

--- a/backend/src/eduops/services/catalogue.py
+++ b/backend/src/eduops/services/catalogue.py
@@ -1,0 +1,46 @@
+import json
+import logging
+from pathlib import Path
+
+from pydantic import ValidationError
+from eduops.models.scenario import ScenarioSchema 
+
+logger = logging.getLogger(__name__)
+
+def get_scenarios_dir() -> Path:
+    """Resolve the absolute path to the bundled scenarios directory."""
+    return Path(__file__).resolve().parent.parent / "scenarios"
+
+def load_bundled_scenarios() -> list[ScenarioSchema]:
+    """
+    Read all JSON files from the scenarios directory, parse them into ScenarioSchema,
+    and return the list of valid scenarios. Handles empty or missing directories gracefully.
+    """
+    scenarios_dir = get_scenarios_dir()
+    scenarios: list[ScenarioSchema] = []
+
+    # Gracefully handle the case where the directory doesn't exist yet
+    if not scenarios_dir.exists() or not scenarios_dir.is_dir():
+        logger.warning(f"Scenarios directory not found at {scenarios_dir}. Returning empty list.")
+        return scenarios
+
+    # Iterate through all JSON files in the directory
+    for filepath in scenarios_dir.glob("*.json"):
+        try:
+            with open(filepath, "r", encoding="utf-8") as f:
+                data = json.load(f)
+                
+            # Parse the raw dictionary into our strict Pydantic model
+            scenario = ScenarioSchema.model_validate(data)
+            scenarios.append(scenario)
+            logger.debug(f"Successfully loaded scenario: {filepath.name}")
+            
+        except (UnicodeDecodeError, json.JSONDecodeError) as e:
+            logger.error(f"Failed to parse invalid JSON in {filepath.name}: {e}")
+        except ValidationError as e:
+            logger.error(f"Schema validation failed for {filepath.name}: {e}")
+        except OSError as e:
+            logger.error(f"Failed to read {filepath.name}: {e}")
+
+    logger.info(f"Loaded {len(scenarios)} bundled scenarios from {scenarios_dir}")
+    return scenarios


### PR DESCRIPTION
### Description
This PR implements the `load_bundled_scenarios()` function in the new Catalogue Service to fulfill Task T023. It builds directly upon the `ScenarioSchema` merged in T016.

**Changes Included:**
* Created `backend/src/eduops/services/catalogue.py`.
* Implemented directory resolution using `pathlib` to reliably locate `backend/src/eduops/scenarios/` regardless of execution context.
* Added graceful error handling for missing directories (returns an empty list instead of crashing).
* Iterates through all `.json` files, parsing them with `json.load()` and validating them strictly via `ScenarioSchema.model_validate()`.
* Added file-level `try...except` blocks to ensure a single malformed JSON file or `ValidationError` does not crash the entire loading process.

### Resolves
Fixes #27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for loading bundled scenarios with automatic validation and resilient handling of malformed or missing files, plus logging of load results.
* **Chores**
  * Include bundled scenario data in the project distribution so pre-configured scenarios are packaged with releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->