### PR TITLE
feat(frontend): implement T021 base API client with health

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ Thumbs.db
 *.tmp
 *.swp
 coverage/
+.github/instructions/copilot-instructions.md

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,0 +1,73 @@
+import type { HealthStatus } from "../types";
+
+const API_BASE_URL = "/api";
+
+interface ErrorResponse {
+    detail?: string;
+}
+
+export class ApiError extends Error {
+    status: number | null;
+    detail?: string;
+
+    constructor(message: string, status: number | null = null, detail?: string) {
+        super(message);
+        this.name = "ApiError";
+        this.status = status;
+        this.detail = detail;
+    }
+}
+
+type RequestOptions = Omit<RequestInit, "body"> & {
+    body?: unknown;
+};
+
+async function request<T>(path: string, options: RequestOptions = {}): Promise<T> {
+    const { body, headers, ...init } = options;
+    const requestHeaders = new Headers(headers);
+
+    if (body !== undefined && !requestHeaders.has("Content-Type")) {
+        requestHeaders.set("Content-Type", "application/json");
+    }
+
+    let response: Response;
+
+    try {
+        response = await fetch(`${API_BASE_URL}${path}`, {
+            ...init,
+            headers: requestHeaders,
+            body: body === undefined ? undefined : JSON.stringify(body),
+        });
+    } catch {
+        throw new ApiError("Network error. Please check your connection and backend server.");
+    }
+
+    if (response.status === 204) {
+        return undefined as T;
+    }
+
+    const contentType = response.headers.get("content-type") ?? "";
+    let payload: unknown = null;
+
+    if (contentType.includes("application/json")) {
+        try {
+            payload = await response.json();
+        } catch {
+            throw new ApiError("Received invalid JSON response from server.", response.status);
+        }
+    }
+
+    if (!response.ok) {
+        const errorPayload = payload as ErrorResponse | null;
+        const detail = errorPayload?.detail;
+        const message = detail ?? `Request failed with status ${response.status}`;
+
+        throw new ApiError(message, response.status, detail);
+    }
+
+    return payload as T;
+}
+
+export async function getHealth(): Promise<HealthStatus> {
+    return request<HealthStatus>("/health", { method: "GET" });
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -3,14 +3,14 @@ import type { HealthStatus } from "../types";
 const API_BASE_URL = "/api";
 
 interface ErrorResponse {
-    detail?: string;
+    detail?: unknown;
 }
 
 export class ApiError extends Error {
     status: number | null;
-    detail?: string;
+    detail?: unknown;
 
-    constructor(message: string, status: number | null = null, detail?: string) {
+    constructor(message: string, status: number | null = null, detail?: unknown) {
         super(message);
         this.name = "ApiError";
         this.status = status;
@@ -38,7 +38,15 @@ async function request<T>(path: string, options: RequestOptions = {}): Promise<T
             headers: requestHeaders,
             body: body === undefined ? undefined : JSON.stringify(body),
         });
-    } catch {
+    } catch (error) {
+        if (
+            error instanceof DOMException
+                ? error.name === "AbortError"
+                : error instanceof Error && error.name === "AbortError"
+        ) {
+            throw error;
+        }
+
         throw new ApiError("Network error. Please check your connection and backend server.");
     }
 
@@ -60,7 +68,21 @@ async function request<T>(path: string, options: RequestOptions = {}): Promise<T
     if (!response.ok) {
         const errorPayload = payload as ErrorResponse | null;
         const detail = errorPayload?.detail;
-        const message = detail ?? `Request failed with status ${response.status}`;
+        let message = `Request failed with status ${response.status}`;
+
+        if (typeof detail === "string" && detail.length > 0) {
+            message = detail;
+        } else if (detail !== undefined) {
+            try {
+                const serialized = JSON.stringify(detail);
+
+                if (serialized && serialized !== "{}" && serialized !== "[]") {
+                    message = serialized;
+                }
+            } catch {
+                // Keep the fallback status message when detail cannot be serialized.
+            }
+        }
 
         throw new ApiError(message, response.status, detail);
     }

--- a/specs/001-core-platform/tasks.md
+++ b/specs/001-core-platform/tasks.md
@@ -78,7 +78,7 @@ Tasks below reinforce this by: one function per task where possible, services sp
 
 - [ ] T019 Implement lifespan context manager in `backend/src/eduops/app.py` — async context manager calling `init_db()` on startup and yielding; shutdown hook placeholder; wire into `create_app(lifespan=...)`
 - [ ] T020 Implement `GET /api/health` endpoint in `backend/src/eduops/api/health.py` — return Docker status, LLM configured flag, active session ID or null, scenario count per contracts/api.md
-- [ ] T021 [P] Create base frontend HTTP client with health function in `frontend/src/services/api.ts` — typed fetch wrapper with base URL `/api`, error handling, `getHealth()` function
+- [x] T021 [P] Create base frontend HTTP client with health function in `frontend/src/services/api.ts` — typed fetch wrapper with base URL `/api`, error handling, `getHealth()` function
 - [ ] T022 [P] Implement frontend SSE client in `frontend/src/services/sse.ts` — `connectLogStream(sessionId)` returning EventSource wrapper with typed handlers for `log`, `container_started`, `container_exited`, `dropped`, `session_ended` events, auto-reconnect
 
 **Checkpoint**: Foundation ready — user story implementation can now begin


### PR DESCRIPTION
## What Does This PR Do?

Implements T021 by adding a typed frontend HTTP client with a base /api wrapper, robust network/HTTP error handling, and a typed getHealth() function. It also adds .github/instructions/copilot-instructions.md to .gitignore and marks T021 complete in the task checklist.

## Closes Issue

closes #20

## Task Reference

T021 [P] Create base frontend HTTP client with health function in frontend/src/services/api.ts — typed fetch wrapper with base URL /api, error handling, getHealth() function

## How Was This Tested?

- cd frontend && npm run build

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] New Python functions have docstrings
- [x] No hardcoded API keys, credentials, or model names
- [x] Module boundaries respected (no cross-module imports)
- [x] Corresponding task in docs/tasks.md checked off in this PR
- [ ] README or docs updated if user-facing behaviour changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Frontend can now query the system health check endpoint.
  * Introduced a centralized API client in the frontend with consistent, structured error handling for clearer failure reporting and no-content responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->