### PR TITLE
feat(frontend): implement SSE client for log streaming

### DIFF
--- a/frontend/src/services/sse.ts
+++ b/frontend/src/services/sse.ts
@@ -6,6 +6,10 @@ import type {
     SessionEndedEvent,
 } from "../types";
 
+/**
+ * A client wrapper for Server-Sent Events (SSE) that provides typed, chainable
+ * event handlers for session log streaming.
+ */
 export interface SseClient {
     onLog: (handler: (event: LogEvent) => void) => SseClient;
     onContainerStarted: (handler: (event: ContainerStartedEvent) => void) => SseClient;
@@ -13,11 +17,20 @@ export interface SseClient {
     onDropped: (handler: (event: DroppedEvent) => void) => SseClient;
     onSessionEnded: (handler: (event: SessionEndedEvent) => void) => SseClient;
     onError: (handler: (event: Event) => void) => SseClient;
+    /** Closes the SSE connection and cleans up listeners. */
     disconnect: () => void;
 }
 
+/**
+ * Connects to the backend log stream for a given session.
+ * Utilizes the browser's native EventSource API, which automatically
+ * handles reconnections if the stream drops unexpectedly.
+ *
+ * @param sessionId - The UUID of the active session
+ * @returns An SseClient instance with chainable event handlers
+ */
 export function connectLogStream(sessionId: string): SseClient {
-    const url = `/api/sessions/${sessionId}/logs`;
+    const url = `/api/sessions/${encodeURIComponent(sessionId)}/logs`;
     const eventSource = new EventSource(url);
 
     // Handlers
@@ -28,55 +41,39 @@ export function connectLogStream(sessionId: string): SseClient {
     let sessionEndedHandler: ((event: SessionEndedEvent) => void) | undefined;
     let errorHandler: ((event: Event) => void) | undefined;
 
+    // Helper to safely parse JSON and dispatch to handler, routing errors to the error handler.
+    const parseAndDispatch = <T>(
+        e: Event,
+        handler: ((event: T) => void) | undefined,
+        eventName: string
+    ) => {
+        if (!handler) return;
+        try {
+            const data = JSON.parse((e as MessageEvent).data);
+            handler(data);
+        } catch (err) {
+            // Route parse failures to the registered error handler if available
+            if (errorHandler) {
+                errorHandler(new ErrorEvent("error", { 
+                    message: `Failed to parse '${eventName}' event`,
+                    error: err 
+                }));
+            } else {
+                console.error(`Failed to parse '${eventName}' event`, err);
+            }
+        }
+    };
+
     // Listeners parsing JSON data payload
-    eventSource.addEventListener("log", (e) => {
-        if (logHandler) {
-            try {
-                logHandler(JSON.parse((e as MessageEvent).data));
-            } catch (err) {
-                console.error("Failed to parse 'log' event", err);
-            }
-        }
-    });
-
-    eventSource.addEventListener("container_started", (e) => {
-        if (containerStartedHandler) {
-            try {
-                containerStartedHandler(JSON.parse((e as MessageEvent).data));
-            } catch (err) {
-                console.error("Failed to parse 'container_started' event", err);
-            }
-        }
-    });
-
-    eventSource.addEventListener("container_exited", (e) => {
-        if (containerExitedHandler) {
-            try {
-                containerExitedHandler(JSON.parse((e as MessageEvent).data));
-            } catch (err) {
-                console.error("Failed to parse 'container_exited' event", err);
-            }
-        }
-    });
-
-    eventSource.addEventListener("dropped", (e) => {
-        if (droppedHandler) {
-            try {
-                droppedHandler(JSON.parse((e as MessageEvent).data));
-            } catch (err) {
-                console.error("Failed to parse 'dropped' event", err);
-            }
-        }
-    });
-
+    eventSource.addEventListener("log", (e) => parseAndDispatch(e, logHandler, "log"));
+    eventSource.addEventListener("container_started", (e) => parseAndDispatch(e, containerStartedHandler, "container_started"));
+    eventSource.addEventListener("container_exited", (e) => parseAndDispatch(e, containerExitedHandler, "container_exited"));
+    eventSource.addEventListener("dropped", (e) => parseAndDispatch(e, droppedHandler, "dropped"));
+    
     eventSource.addEventListener("session_ended", (e) => {
-        if (sessionEndedHandler) {
-            try {
-                sessionEndedHandler(JSON.parse((e as MessageEvent).data));
-            } catch (err) {
-                console.error("Failed to parse 'session_ended' event", err);
-            }
-        }
+        parseAndDispatch(e, sessionEndedHandler, "session_ended");
+        // Streams are explicitly closed by backend, so close client to prevent auto-reconnect loops
+        eventSource.close();
     });
 
     eventSource.addEventListener("error", (e) => {

--- a/frontend/src/services/sse.ts
+++ b/frontend/src/services/sse.ts
@@ -1,0 +1,119 @@
+import type {
+    LogEvent,
+    ContainerStartedEvent,
+    ContainerExitedEvent,
+    DroppedEvent,
+    SessionEndedEvent,
+} from "../types";
+
+export interface SseClient {
+    onLog: (handler: (event: LogEvent) => void) => SseClient;
+    onContainerStarted: (handler: (event: ContainerStartedEvent) => void) => SseClient;
+    onContainerExited: (handler: (event: ContainerExitedEvent) => void) => SseClient;
+    onDropped: (handler: (event: DroppedEvent) => void) => SseClient;
+    onSessionEnded: (handler: (event: SessionEndedEvent) => void) => SseClient;
+    onError: (handler: (event: Event) => void) => SseClient;
+    disconnect: () => void;
+}
+
+export function connectLogStream(sessionId: string): SseClient {
+    const url = `/api/sessions/${sessionId}/logs`;
+    const eventSource = new EventSource(url);
+
+    // Handlers
+    let logHandler: ((event: LogEvent) => void) | undefined;
+    let containerStartedHandler: ((event: ContainerStartedEvent) => void) | undefined;
+    let containerExitedHandler: ((event: ContainerExitedEvent) => void) | undefined;
+    let droppedHandler: ((event: DroppedEvent) => void) | undefined;
+    let sessionEndedHandler: ((event: SessionEndedEvent) => void) | undefined;
+    let errorHandler: ((event: Event) => void) | undefined;
+
+    // Listeners parsing JSON data payload
+    eventSource.addEventListener("log", (e) => {
+        if (logHandler) {
+            try {
+                logHandler(JSON.parse((e as MessageEvent).data));
+            } catch (err) {
+                console.error("Failed to parse 'log' event", err);
+            }
+        }
+    });
+
+    eventSource.addEventListener("container_started", (e) => {
+        if (containerStartedHandler) {
+            try {
+                containerStartedHandler(JSON.parse((e as MessageEvent).data));
+            } catch (err) {
+                console.error("Failed to parse 'container_started' event", err);
+            }
+        }
+    });
+
+    eventSource.addEventListener("container_exited", (e) => {
+        if (containerExitedHandler) {
+            try {
+                containerExitedHandler(JSON.parse((e as MessageEvent).data));
+            } catch (err) {
+                console.error("Failed to parse 'container_exited' event", err);
+            }
+        }
+    });
+
+    eventSource.addEventListener("dropped", (e) => {
+        if (droppedHandler) {
+            try {
+                droppedHandler(JSON.parse((e as MessageEvent).data));
+            } catch (err) {
+                console.error("Failed to parse 'dropped' event", err);
+            }
+        }
+    });
+
+    eventSource.addEventListener("session_ended", (e) => {
+        if (sessionEndedHandler) {
+            try {
+                sessionEndedHandler(JSON.parse((e as MessageEvent).data));
+            } catch (err) {
+                console.error("Failed to parse 'session_ended' event", err);
+            }
+        }
+    });
+
+    eventSource.addEventListener("error", (e) => {
+        if (errorHandler) {
+            errorHandler(e);
+        }
+    });
+
+    const client: SseClient = {
+        onLog: (handler) => {
+            logHandler = handler;
+            return client;
+        },
+        onContainerStarted: (handler) => {
+            containerStartedHandler = handler;
+            return client;
+        },
+        onContainerExited: (handler) => {
+            containerExitedHandler = handler;
+            return client;
+        },
+        onDropped: (handler) => {
+            droppedHandler = handler;
+            return client;
+        },
+        onSessionEnded: (handler) => {
+            sessionEndedHandler = handler;
+            return client;
+        },
+        onError: (handler) => {
+            errorHandler = handler;
+            return client;
+        },
+        disconnect: () => {
+            eventSource.close();
+        },
+    };
+
+    return client;
+}

--- a/frontend/src/services/sse.ts
+++ b/frontend/src/services/sse.ts
@@ -17,7 +17,7 @@ export interface SseClient {
     onDropped: (handler: (event: DroppedEvent) => void) => SseClient;
     onSessionEnded: (handler: (event: SessionEndedEvent) => void) => SseClient;
     onError: (handler: (event: Event) => void) => SseClient;
-    /** Closes the SSE connection and cleans up listeners. */
+    /** Closes the underlying EventSource connection. */
     disconnect: () => void;
 }
 
@@ -79,6 +79,8 @@ export function connectLogStream(sessionId: string): SseClient {
     eventSource.addEventListener("error", (e) => {
         if (errorHandler) {
             errorHandler(e);
+        } else {
+            console.error("SSE connection error", e);
         }
     });
 

--- a/specs/001-core-platform/tasks.md
+++ b/specs/001-core-platform/tasks.md
@@ -79,7 +79,7 @@ Tasks below reinforce this by: one function per task where possible, services sp
 - [x] T019 Implement lifespan context manager in `backend/src/eduops/app.py` — async context manager calling `init_db()` on startup and yielding; shutdown hook placeholder; wire into `create_app(lifespan=...)`
 - [x] T020 Implement `GET /api/health` endpoint in `backend/src/eduops/api/health.py` — return Docker status, LLM configured flag, active session ID or null, scenario count per contracts/api.md
 - [x] T021 [P] Create base frontend HTTP client with health function in `frontend/src/services/api.ts` — typed fetch wrapper with base URL `/api`, error handling, `getHealth()` function
-- [ ] T022 [P] Implement frontend SSE client in `frontend/src/services/sse.ts` — `connectLogStream(sessionId)` returning EventSource wrapper with typed handlers for `log`, `container_started`, `container_exited`, `dropped`, `session_ended` events, auto-reconnect
+- [x] T022 [P] Implement frontend SSE client in `frontend/src/services/sse.ts` — `connectLogStream(sessionId)` returning EventSource wrapper with typed handlers for `log`, `container_started`, `container_exited`, `dropped`, `session_ended` events, auto-reconnect
 
 **Checkpoint**: Foundation ready — user story implementation can now begin
 


### PR DESCRIPTION
## What Does This PR Do?

Implements `frontend/src/services/sse.ts` with `connectLogStream(sessionId)` returning an `SseClient` wrapper. This provides typed event listeners (`onLog`, `onContainerStarted`, etc.) based on the HTML `EventSource` for live container log streaming.

## Closes Issue

closes #25

## Task Reference

T022 [P] Implement frontend SSE client in `frontend/src/services/sse.ts` — `connectLogStream(sessionId)` returning EventSource wrapper with typed handlers for `log`, `container_started`, `container_exited`, `dropped`, `session_ended` events, auto-reconnect

## How Was This Tested?

Ran `npm run typecheck` and verified static typings against the API definitions from `frontend/src/types/index.ts`.

## Checklist

- [x] Commit messages follow Conventional Commits
- [ ] New Python functions have docstrings
- [x] No hardcoded API keys, credentials, or model names
- [x] Module boundaries respected (no cross-module imports)
- [x] Corresponding task in docs/tasks.md checked off in this PR
- [ ] README or docs updated if user-facing behaviour changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time session log streaming with live event notifications for logs, container lifecycle (started/exited), dropped messages, and session end; includes reliable error reporting and an explicit disconnect to stop streams.
* **Chores**
  * Updated project task checklist to mark the session log streaming work as completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->