### PR TITLE
feat(catalogue): T024 — implement upsert_scenario()

### DIFF
--- a/backend/src/eduops/services/catalogue.py
+++ b/backend/src/eduops/services/catalogue.py
@@ -1,15 +1,19 @@
 import json
 import logging
+import sqlite3
+from datetime import datetime, timezone
 from pathlib import Path
 
 from pydantic import ValidationError
-from eduops.models.scenario import ScenarioSchema 
+from eduops.models.scenario import ScenarioSchema
 
 logger = logging.getLogger(__name__)
+
 
 def get_scenarios_dir() -> Path:
     """Resolve the absolute path to the bundled scenarios directory."""
     return Path(__file__).resolve().parent.parent / "scenarios"
+
 
 def load_bundled_scenarios() -> list[ScenarioSchema]:
     """
@@ -21,7 +25,9 @@ def load_bundled_scenarios() -> list[ScenarioSchema]:
 
     # Gracefully handle the case where the directory doesn't exist yet
     if not scenarios_dir.exists() or not scenarios_dir.is_dir():
-        logger.warning(f"Scenarios directory not found at {scenarios_dir}. Returning empty list.")
+        logger.warning(
+            f"Scenarios directory not found at {scenarios_dir}. Returning empty list."
+        )
         return scenarios
 
     # Iterate through all JSON files in the directory
@@ -29,12 +35,12 @@ def load_bundled_scenarios() -> list[ScenarioSchema]:
         try:
             with open(filepath, "r", encoding="utf-8") as f:
                 data = json.load(f)
-                
+
             # Parse the raw dictionary into our strict Pydantic model
             scenario = ScenarioSchema.model_validate(data)
             scenarios.append(scenario)
             logger.debug(f"Successfully loaded scenario: {filepath.name}")
-            
+
         except (UnicodeDecodeError, json.JSONDecodeError) as e:
             logger.error(f"Failed to parse invalid JSON in {filepath.name}: {e}")
         except ValidationError as e:
@@ -44,3 +50,68 @@ def load_bundled_scenarios() -> list[ScenarioSchema]:
 
     logger.info(f"Loaded {len(scenarios)} bundled scenarios from {scenarios_dir}")
     return scenarios
+
+
+def upsert_scenario(
+    conn: sqlite3.Connection,
+    scenario: ScenarioSchema,
+    embedding: bytes,
+    source: str,
+    title: str,
+    difficulty: str,
+    tags: list[str],
+    created_at: str | None = None,
+) -> None:
+    """
+    Insert or update a scenario row in the DB by ID.
+
+    Uses ``INSERT OR REPLACE INTO`` so the call is idempotent: calling it
+    again with the same ``scenario.id`` will overwrite the existing row,
+    which is the desired behaviour for bundled scenario startup upserts and
+    for updating a generated scenario's embedding.
+
+    Args:
+        conn:       Active SQLite connection (caller controls the transaction).
+        scenario:   Validated ScenarioSchema to persist.
+        embedding:  Pre-computed 384-dim float32 vector serialised as bytes
+                    (1536 bytes).  Stored directly as a BLOB.
+        source:     Origin of the scenario — ``'bundled'`` or ``'generated'``.
+        title:      Human-readable scenario title (maps to ``scenarios.title``).
+        difficulty: One of ``'easy'``, ``'medium'``, or ``'hard'``.
+        tags:       List of tag strings; serialised as a JSON array for storage.
+        created_at: ISO 8601 timestamp string.  Defaults to the current UTC
+                    time when omitted.
+    """
+    if source not in ("bundled", "generated"):
+        raise ValueError(f"source must be 'bundled' or 'generated', got {source!r}")
+    if difficulty not in ("easy", "medium", "hard"):
+        raise ValueError(
+            f"difficulty must be 'easy', 'medium', or 'hard', got {difficulty!r}"
+        )
+
+    if created_at is None:
+        created_at = datetime.now(timezone.utc).isoformat()
+
+    schema_json: str = scenario.model_dump_json()
+    tags_json: str = json.dumps(tags)
+
+    conn.execute(
+        """
+        INSERT OR REPLACE INTO scenarios
+            (id, title, description, difficulty, tags, source, schema_json, embedding, created_at)
+        VALUES
+            (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            scenario.id,
+            title,
+            scenario.description,
+            difficulty,
+            tags_json,
+            source,
+            schema_json,
+            embedding,
+            created_at,
+        ),
+    )
+    logger.debug("Upserted scenario id=%s source=%s", scenario.id, source)

--- a/backend/src/eduops/services/catalogue.py
+++ b/backend/src/eduops/services/catalogue.py
@@ -88,6 +88,8 @@ def upsert_scenario(
         raise ValueError(
             f"difficulty must be 'easy', 'medium', or 'hard', got {difficulty!r}"
         )
+    if len(embedding) != 1536:
+        raise ValueError(f"embedding must be exactly 1536 bytes, got {len(embedding)}")
 
     if created_at is None:
         created_at = datetime.now(timezone.utc).isoformat()
@@ -97,10 +99,18 @@ def upsert_scenario(
 
     conn.execute(
         """
-        INSERT OR REPLACE INTO scenarios
+        INSERT INTO scenarios
             (id, title, description, difficulty, tags, source, schema_json, embedding, created_at)
         VALUES
             (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(id) DO UPDATE SET
+            title = excluded.title,
+            description = excluded.description,
+            difficulty = excluded.difficulty,
+            tags = excluded.tags,
+            source = excluded.source,
+            schema_json = excluded.schema_json,
+            embedding = excluded.embedding
         """,
         (
             scenario.id,

--- a/specs/001-core-platform/tasks.md
+++ b/specs/001-core-platform/tasks.md
@@ -94,7 +94,7 @@ Tasks below reinforce this by: one function per task where possible, services sp
 ### Catalogue Service
 
 - [x] T023 [P] [US1] Implement `load_bundled_scenarios()` in `backend/src/eduops/services/catalogue.py` — read all JSON files from `backend/src/eduops/scenarios/` directory, parse each into ScenarioSchema, return list
-- [ ] T024 [US1] Implement `upsert_scenario()` in `backend/src/eduops/services/catalogue.py` — insert-or-update a scenario row in the DB by ID, store serialised schema_json and embedding BLOB
+- [x] T024 [US1] Implement `upsert_scenario()` in `backend/src/eduops/services/catalogue.py` — insert-or-update a scenario row in the DB by ID, store serialised schema_json and embedding BLOB
 - [ ] T025 [US1] Implement `list_scenarios()` and `get_scenario()` in `backend/src/eduops/services/catalogue.py` — list with optional difficulty/source filters, get by ID returning full scenario or None
 
 ### Scenario API


### PR DESCRIPTION
## Summary

Implements `upsert_scenario()` in `backend/src/eduops/services/catalogue.py`, closing issue #34 (T024).

## What was done

- Added `upsert_scenario(conn, scenario, embedding, source, title, difficulty, tags, created_at=None)` to `catalogue.py`
- Uses `INSERT OR REPLACE INTO scenarios` — idempotent upsert keyed on `scenario.id`
- Serialises `ScenarioSchema` to `schema_json` via `model_dump_json()`
- Serialises `tags: list[str]` as a JSON array string per the data-model spec
- Stores `embedding` bytes directly as a BLOB
- Validates `source` and `difficulty` values before executing and raises `ValueError` on invalid input
- `created_at` defaults to current UTC time if not supplied
- All parameterised queries — no string interpolation (constitution constraint)

## Testing

Smoke-tested manually with an in-memory SQLite DB (using `init_db` + `get_db`):

- ✅ Basic insert: row present with correct field values
- ✅ Idempotent upsert: second call overwrites row, no duplicate rows 
- ✅ Invalid `source` raises `ValueError`
- ✅ Invalid `difficulty` raises `ValueError`
- ✅ `ruff check` passes; `ruff format` applied

## Acceptance Criteria

- [x] `upsert_scenario()` function in catalogue.py
- [x] Insert-or-update by scenario ID
- [x] Stores serialised schema_json
- [x] Stores embedding as BLOB
- [x] Uses parameterised queries (no string interpolation)

Closes #34


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced scenario management with validation of source and difficulty
  * Automatic UTC timestamp assignment for new scenarios
  * More reliable scenario save/update behavior to improve data consistency

* **Documentation**
  * Implementation task for scenario upsert marked as completed in the project tasks
<!-- end of auto-generated comment: release notes by coderabbit.ai -->