### PR TITLE
feat(catalogue): implement list_scenarios and get_scenario (T025)

### DIFF
--- a/backend/src/eduops/services/catalogue.py
+++ b/backend/src/eduops/services/catalogue.py
@@ -135,8 +135,17 @@ def _parse_tags(raw_tags: str) -> list[str]:
         value = json.loads(raw_tags)
         if isinstance(value, list) and all(isinstance(tag, str) for tag in value):
             return value
-    except json.JSONDecodeError:
-        logger.warning("Failed to parse scenario tags JSON; returning empty tag list")
+        logger.warning(
+            "Scenario tags JSON has unexpected structure; expected list[str], got %r. "
+            "Returning empty tag list.",
+            value,
+        )
+    except json.JSONDecodeError as exc:
+        logger.warning(
+            "Failed to parse scenario tags JSON; returning empty tag list. Error: %s",
+            exc,
+            exc_info=True,
+        )
     return []
 
 

--- a/backend/src/eduops/services/catalogue.py
+++ b/backend/src/eduops/services/catalogue.py
@@ -3,8 +3,10 @@ import logging
 import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 
 from pydantic import ValidationError
+from eduops.db import fetchall, fetchone, get_db
 from eduops.models.scenario import ScenarioSchema
 
 logger = logging.getLogger(__name__)
@@ -125,3 +127,84 @@ def upsert_scenario(
         ),
     )
     logger.debug("Upserted scenario id=%s source=%s", scenario.id, source)
+
+
+def _parse_tags(raw_tags: str) -> list[str]:
+    """Convert persisted JSON tags into a list of strings."""
+    try:
+        value = json.loads(raw_tags)
+        if isinstance(value, list) and all(isinstance(tag, str) for tag in value):
+            return value
+    except json.JSONDecodeError:
+        logger.warning("Failed to parse scenario tags JSON; returning empty tag list")
+    return []
+
+
+def list_scenarios(
+    difficulty: str | None = None,
+    source: str | None = None,
+    db_path: Path | None = None,
+) -> list[dict[str, Any]]:
+    """Return scenario summaries, optionally filtered by difficulty and source."""
+    query = (
+        "SELECT id, title, description, difficulty, tags, source, created_at "
+        "FROM scenarios"
+    )
+    where_clauses: list[str] = []
+    params: list[Any] = []
+
+    if difficulty is not None:
+        where_clauses.append("difficulty = ?")
+        params.append(difficulty)
+
+    if source is not None:
+        where_clauses.append("source = ?")
+        params.append(source)
+
+    if where_clauses:
+        query += " WHERE " + " AND ".join(where_clauses)
+
+    query += " ORDER BY created_at DESC"
+
+    with get_db(db_path) as conn:
+        rows = fetchall(conn, query, tuple(params))
+
+    # Summary response intentionally excludes schema_json and embedding.
+    return [
+        {
+            "id": row["id"],
+            "title": row["title"],
+            "description": row["description"],
+            "difficulty": row["difficulty"],
+            "tags": _parse_tags(row["tags"]),
+            "source": row["source"],
+            "created_at": row["created_at"],
+        }
+        for row in rows
+    ]
+
+
+def get_scenario(scenario_id: str, db_path: Path | None = None) -> dict[str, Any] | None:
+    """Return a full scenario record by id, or None if not found."""
+    query = (
+        "SELECT id, title, description, difficulty, tags, source, schema_json, embedding, created_at "
+        "FROM scenarios WHERE id = ?"
+    )
+
+    with get_db(db_path) as conn:
+        row = fetchone(conn, query, (scenario_id,))
+
+    if row is None:
+        return None
+
+    return {
+        "id": row["id"],
+        "title": row["title"],
+        "description": row["description"],
+        "difficulty": row["difficulty"],
+        "tags": _parse_tags(row["tags"]),
+        "source": row["source"],
+        "schema_json": row["schema_json"],
+        "embedding": row["embedding"],
+        "created_at": row["created_at"],
+    }

--- a/backend/tests/test_catalogue_service.py
+++ b/backend/tests/test_catalogue_service.py
@@ -162,3 +162,61 @@ def test_list_and_get_are_safe_with_sql_like_input_values(db_path: Path) -> None
     assert list_scenarios(source=injected_filter, db_path=db_path) == []
     assert get_scenario(injected_id, db_path=db_path) is None
     assert get_scenario("safe-id", db_path=db_path) is not None
+
+
+def test_list_and_get_return_empty_tags_for_invalid_payloads(db_path: Path) -> None:
+    """Invalid tags JSON should not raise and should decode to an empty list."""
+    init_db(db_path)
+
+    with get_db(db_path) as conn:
+        execute(
+            conn,
+            (
+                "INSERT INTO scenarios "
+                "(id, title, description, difficulty, tags, source, schema_json, embedding, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
+            ),
+            (
+                "invalid-json-tags",
+                "Invalid JSON Tags",
+                "Bad tags payload",
+                "easy",
+                "not-json",
+                "bundled",
+                "{}",
+                b"\x00" * 1536,
+                "2026-03-19T15:00:00Z",
+            ),
+            commit=True,
+        )
+        execute(
+            conn,
+            (
+                "INSERT INTO scenarios "
+                "(id, title, description, difficulty, tags, source, schema_json, embedding, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
+            ),
+            (
+                "json-non-list-tags",
+                "JSON Non-List Tags",
+                "Tags is not a list",
+                "medium",
+                json.dumps({"tag": "docker"}),
+                "generated",
+                "{}",
+                b"\x00" * 1536,
+                "2026-03-19T16:00:00Z",
+            ),
+            commit=True,
+        )
+
+    listed = list_scenarios(db_path=db_path)
+    listed_by_id = {item["id"]: item for item in listed}
+
+    assert listed_by_id["invalid-json-tags"]["tags"] == []
+    assert listed_by_id["json-non-list-tags"]["tags"] == []
+
+    assert get_scenario("invalid-json-tags", db_path=db_path) is not None
+    assert get_scenario("invalid-json-tags", db_path=db_path)["tags"] == []
+    assert get_scenario("json-non-list-tags", db_path=db_path) is not None
+    assert get_scenario("json-non-list-tags", db_path=db_path)["tags"] == []

--- a/backend/tests/test_catalogue_service.py
+++ b/backend/tests/test_catalogue_service.py
@@ -1,0 +1,164 @@
+"""Tests for scenario listing and retrieval in eduops.services.catalogue."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from eduops.db import execute, get_db, init_db
+from eduops.services.catalogue import get_scenario, list_scenarios
+
+
+def _insert_scenario(
+    db_path: Path,
+    *,
+    scenario_id: str,
+    title: str,
+    description: str,
+    difficulty: str,
+    tags: list[str],
+    source: str,
+    schema_json: str,
+    created_at: str,
+) -> None:
+    with get_db(db_path) as conn:
+        execute(
+            conn,
+            (
+                "INSERT INTO scenarios "
+                "(id, title, description, difficulty, tags, source, schema_json, embedding, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
+            ),
+            (
+                scenario_id,
+                title,
+                description,
+                difficulty,
+                json.dumps(tags),
+                source,
+                schema_json,
+                b"\x00" * 1536,
+                created_at,
+            ),
+            commit=True,
+        )
+
+
+def test_list_scenarios_returns_summaries_without_schema_json(db_path: Path) -> None:
+    """list_scenarios should return summary fields only and parse tags."""
+    init_db(db_path)
+    _insert_scenario(
+        db_path,
+        scenario_id="s1",
+        title="List Containers",
+        description="Use docker ps",
+        difficulty="easy",
+        tags=["docker", "containers"],
+        source="bundled",
+        schema_json='{"hidden": true}',
+        created_at="2026-03-19T10:00:00Z",
+    )
+
+    scenarios = list_scenarios(db_path=db_path)
+
+    assert len(scenarios) == 1
+    assert scenarios[0]["id"] == "s1"
+    assert scenarios[0]["tags"] == ["docker", "containers"]
+    assert "schema_json" not in scenarios[0]
+    assert "embedding" not in scenarios[0]
+
+
+def test_list_scenarios_applies_optional_difficulty_and_source_filters(db_path: Path) -> None:
+    """list_scenarios should support independent and combined optional filters."""
+    init_db(db_path)
+    _insert_scenario(
+        db_path,
+        scenario_id="s1",
+        title="Easy Bundled",
+        description="d1",
+        difficulty="easy",
+        tags=["a"],
+        source="bundled",
+        schema_json="{}",
+        created_at="2026-03-19T10:00:00Z",
+    )
+    _insert_scenario(
+        db_path,
+        scenario_id="s2",
+        title="Hard Generated",
+        description="d2",
+        difficulty="hard",
+        tags=["b"],
+        source="generated",
+        schema_json="{}",
+        created_at="2026-03-19T11:00:00Z",
+    )
+    _insert_scenario(
+        db_path,
+        scenario_id="s3",
+        title="Hard Bundled",
+        description="d3",
+        difficulty="hard",
+        tags=["c"],
+        source="bundled",
+        schema_json="{}",
+        created_at="2026-03-19T12:00:00Z",
+    )
+
+    hard_only = list_scenarios(difficulty="hard", db_path=db_path)
+    bundled_only = list_scenarios(source="bundled", db_path=db_path)
+    hard_bundled = list_scenarios(difficulty="hard", source="bundled", db_path=db_path)
+
+    assert {scenario["id"] for scenario in hard_only} == {"s2", "s3"}
+    assert {scenario["id"] for scenario in bundled_only} == {"s1", "s3"}
+    assert [scenario["id"] for scenario in hard_bundled] == ["s3"]
+
+
+def test_get_scenario_returns_full_record_or_none(db_path: Path) -> None:
+    """get_scenario should return full stored fields or None for unknown IDs."""
+    init_db(db_path)
+    _insert_scenario(
+        db_path,
+        scenario_id="s1",
+        title="Inspect Image",
+        description="Use docker image inspect",
+        difficulty="medium",
+        tags=["images"],
+        source="generated",
+        schema_json='{"checks": [1, 2]}',
+        created_at="2026-03-19T13:00:00Z",
+    )
+
+    found = get_scenario("s1", db_path=db_path)
+    missing = get_scenario("does-not-exist", db_path=db_path)
+
+    assert found is not None
+    assert found["id"] == "s1"
+    assert found["title"] == "Inspect Image"
+    assert found["tags"] == ["images"]
+    assert found["schema_json"] == '{"checks": [1, 2]}'
+    assert isinstance(found["embedding"], bytes)
+    assert missing is None
+
+
+def test_list_and_get_are_safe_with_sql_like_input_values(db_path: Path) -> None:
+    """Inputs must be bound as SQL params, not interpolated into queries."""
+    init_db(db_path)
+    _insert_scenario(
+        db_path,
+        scenario_id="safe-id",
+        title="Safe",
+        description="Safe",
+        difficulty="easy",
+        tags=["safe"],
+        source="bundled",
+        schema_json="{}",
+        created_at="2026-03-19T14:00:00Z",
+    )
+
+    injected_filter = "bundled' OR 1=1 --"
+    injected_id = "safe-id' OR 1=1 --"
+
+    assert list_scenarios(source=injected_filter, db_path=db_path) == []
+    assert get_scenario(injected_id, db_path=db_path) is None
+    assert get_scenario("safe-id", db_path=db_path) is not None

--- a/backend/tests/test_catalogue_service.py
+++ b/backend/tests/test_catalogue_service.py
@@ -216,7 +216,10 @@ def test_list_and_get_return_empty_tags_for_invalid_payloads(db_path: Path) -> N
     assert listed_by_id["invalid-json-tags"]["tags"] == []
     assert listed_by_id["json-non-list-tags"]["tags"] == []
 
-    assert get_scenario("invalid-json-tags", db_path=db_path) is not None
-    assert get_scenario("invalid-json-tags", db_path=db_path)["tags"] == []
-    assert get_scenario("json-non-list-tags", db_path=db_path) is not None
-    assert get_scenario("json-non-list-tags", db_path=db_path)["tags"] == []
+    result = get_scenario("invalid-json-tags", db_path=db_path)
+    assert result is not None
+    assert result["tags"] == []
+
+    result = get_scenario("json-non-list-tags", db_path=db_path)
+    assert result is not None
+    assert result["tags"] == []


### PR DESCRIPTION
## Summary
Implements T025 by adding scenario catalogue retrieval functions in the backend service layer.

### What was implemented
- Added list_scenarios(difficulty=None, source=None, db_path=None) to return scenario summaries
- Added get_scenario(scenario_id, db_path=None) to return a full scenario row or None
- Added JSON tag parsing helper for robust tags decoding
- Added focused backend tests for summary shape, filters, full retrieval, and SQL-injection safety

## Acceptance Criteria
- [x] list_scenarios() with optional difficulty and source filters
- [x] get_scenario(id) returning full scenario or None
- [x] Both use parameterized queries
- [x] list_scenarios returns scenario summaries excluding schema_json

## Files Changed
- backend/src/eduops/seImplements T025 for User Story 1 by adding scenario catalogue retrieval functions in the backend service layer.

### What was implemented
- Added list_scenarios(difficulty=None, source=None, db_path=None) to return scenario summaries
- Added get_scenarmp
### What was implemented
- Added list_scenarios(difficulty=None, source=None, db_path=None) to return scenari#32-  git status --short --branch && git branch --show-current && gh pr list --head feature/t025-list-get-scenarios-dev --state open
 cd /Users/ren/EDUOPS/eduops && cat > /tmp/t025_pr_body.md <<'EOF'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * List scenarios with optional difficulty and source filters.
  * Retrieve full details for an individual scenario.

* **Tests**
  * Added tests verifying listing returns summaries (omitting heavy fields) and filtering behavior.
  * Added tests for single-scenario retrieval, robustness of tag decoding, and resilience to malicious input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->