### PR TITLE
feat(api): implement GET /api/scenarios endpoint (T026)

### DIFF
--- a/backend/src/eduops/api/__init__.py
+++ b/backend/src/eduops/api/__init__.py
@@ -1,7 +1,9 @@
 from fastapi import APIRouter
 from eduops.api.health import router as health_router
+from eduops.api.scenarios import router as scenarios_router
 
 api_router = APIRouter()
 
 # Mount the health router
 api_router.include_router(health_router, tags=["health"])
+api_router.include_router(scenarios_router, tags=["scenarios"])

--- a/backend/src/eduops/api/scenarios.py
+++ b/backend/src/eduops/api/scenarios.py
@@ -1,0 +1,41 @@
+from typing import Literal
+
+from fastapi import APIRouter, Query
+from pydantic import BaseModel, ConfigDict
+
+from eduops.services.catalogue import list_scenarios
+
+router = APIRouter()
+
+Difficulty = Literal["easy", "medium", "hard"]
+Source = Literal["bundled", "generated"]
+
+
+class ScenarioSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    id: str
+    title: str
+    description: str
+    difficulty: Difficulty
+    tags: list[str]
+    source: Source
+    created_at: str
+
+
+class ScenarioListResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    scenarios: list[ScenarioSummary]
+
+
+@router.get("/scenarios", response_model=ScenarioListResponse)
+async def get_scenarios(
+    difficulty: Difficulty | None = Query(default=None),
+    source: Source | None = Query(default=None),
+) -> ScenarioListResponse:
+    """Return scenario summaries, optionally filtered by difficulty and source."""
+    scenarios = list_scenarios(difficulty=difficulty, source=source)
+    return ScenarioListResponse(
+        scenarios=[ScenarioSummary.model_validate(scenario) for scenario in scenarios]
+    )

--- a/backend/src/eduops/api/scenarios.py
+++ b/backend/src/eduops/api/scenarios.py
@@ -1,6 +1,6 @@
 from typing import Literal
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Query, Request
 from pydantic import BaseModel, ConfigDict
 from starlette.concurrency import run_in_threadpool
 
@@ -32,14 +32,17 @@ class ScenarioListResponse(BaseModel):
 
 @router.get("/scenarios", response_model=ScenarioListResponse)
 async def get_scenarios(
+    request: Request,
     difficulty: Difficulty | None = Query(default=None),
     source: Source | None = Query(default=None),
 ) -> ScenarioListResponse:
     """Return scenario summaries, optionally filtered by difficulty and source."""
+    db_path = getattr(request.app.state, "db_path", None)
     scenarios = await run_in_threadpool(
         list_scenarios,
         difficulty=difficulty,
         source=source,
+        db_path=db_path,
     )
     return ScenarioListResponse(
         scenarios=[ScenarioSummary.model_validate(scenario) for scenario in scenarios]

--- a/backend/src/eduops/api/scenarios.py
+++ b/backend/src/eduops/api/scenarios.py
@@ -2,6 +2,7 @@ from typing import Literal
 
 from fastapi import APIRouter, Query
 from pydantic import BaseModel, ConfigDict
+from starlette.concurrency import run_in_threadpool
 
 from eduops.services.catalogue import list_scenarios
 
@@ -35,7 +36,11 @@ async def get_scenarios(
     source: Source | None = Query(default=None),
 ) -> ScenarioListResponse:
     """Return scenario summaries, optionally filtered by difficulty and source."""
-    scenarios = list_scenarios(difficulty=difficulty, source=source)
+    scenarios = await run_in_threadpool(
+        list_scenarios,
+        difficulty=difficulty,
+        source=source,
+    )
     return ScenarioListResponse(
         scenarios=[ScenarioSummary.model_validate(scenario) for scenario in scenarios]
     )

--- a/backend/src/eduops/app.py
+++ b/backend/src/eduops/app.py
@@ -28,6 +28,7 @@ def create_app(db_path: Path | None = None) -> FastAPI:
 
     # We attach the lifespan manager right when we create the FastAPI instance
     app = FastAPI(title="eduops Core Platform", lifespan=lifespan)
+    app.state.db_path = db_path
 
     # Configure CORS for development — allow all origins (no credentials needed;
     # the Vite dev proxy forwards /api requests, so cookies/auth headers are not

--- a/backend/tests/test_scenarios_api.py
+++ b/backend/tests/test_scenarios_api.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
+from collections.abc import AsyncGenerator
 from typing import Any
+from pathlib import Path
 
 import pytest
+import pytest_asyncio
 from httpx import AsyncClient
+from httpx import ASGITransport
 
 from eduops.api import scenarios as scenarios_api
+from eduops.app import create_app
 
 
 def _scenario_summary(scenario_id: str, difficulty: str, source: str) -> dict[str, Any]:
@@ -24,10 +29,11 @@ def _scenario_summary(scenario_id: str, difficulty: str, source: str) -> dict[st
 
 @pytest.mark.asyncio
 async def test_get_scenarios_returns_contract_shape(
-    async_client: AsyncClient,
+    scenarios_api_client: tuple[AsyncClient, Path],
     monkeypatch: Any,
 ) -> None:
     """Endpoint should return scenario summaries under the 'scenarios' key."""
+    async_client, expected_db_path = scenarios_api_client
 
     def fake_list_scenarios(
         difficulty: str | None = None,
@@ -36,7 +42,7 @@ async def test_get_scenarios_returns_contract_shape(
     ) -> list[dict[str, Any]]:
         assert difficulty is None
         assert source is None
-        assert db_path is None
+        assert db_path == expected_db_path
         return [_scenario_summary("s1", "easy", "bundled")]
 
     monkeypatch.setattr(scenarios_api, "list_scenarios", fake_list_scenarios)
@@ -53,10 +59,11 @@ async def test_get_scenarios_returns_contract_shape(
 
 @pytest.mark.asyncio
 async def test_get_scenarios_forwards_optional_filters(
-    async_client: AsyncClient,
+    scenarios_api_client: tuple[AsyncClient, Path],
     monkeypatch: Any,
 ) -> None:
     """difficulty and source query params should be forwarded to service layer."""
+    async_client, expected_db_path = scenarios_api_client
     captured: dict[str, Any] = {}
 
     def fake_list_scenarios(
@@ -74,7 +81,22 @@ async def test_get_scenarios_forwards_optional_filters(
     response = await async_client.get("/api/scenarios?difficulty=hard&source=generated")
 
     assert response.status_code == 200
-    assert captured == {"difficulty": "hard", "source": "generated", "db_path": None}
+    assert captured == {
+        "difficulty": "hard",
+        "source": "generated",
+        "db_path": expected_db_path,
+    }
     payload = response.json()
     assert payload["scenarios"][0]["difficulty"] == "hard"
     assert payload["scenarios"][0]["source"] == "generated"
+
+
+@pytest_asyncio.fixture()
+async def scenarios_api_client(tmp_path: Path) -> AsyncGenerator[tuple[AsyncClient, Path], None]:
+    """Create a per-test app/client using an isolated temporary SQLite file."""
+    db_path = tmp_path / "scenarios_api_test.db"
+    app = create_app(db_path=db_path)
+    transport = ASGITransport(app=app)
+
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client, db_path

--- a/backend/tests/test_scenarios_api.py
+++ b/backend/tests/test_scenarios_api.py
@@ -1,0 +1,80 @@
+"""Tests for GET /api/scenarios endpoint."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from httpx import AsyncClient
+
+from eduops.api import scenarios as scenarios_api
+
+
+def _scenario_summary(scenario_id: str, difficulty: str, source: str) -> dict[str, Any]:
+    return {
+        "id": scenario_id,
+        "title": f"Scenario {scenario_id}",
+        "description": "Practice Docker basics",
+        "difficulty": difficulty,
+        "tags": ["docker", "practice"],
+        "source": source,
+        "created_at": "2026-03-19T12:00:00Z",
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_scenarios_returns_contract_shape(
+    async_client: AsyncClient,
+    monkeypatch: Any,
+) -> None:
+    """Endpoint should return scenario summaries under the 'scenarios' key."""
+
+    def fake_list_scenarios(
+        difficulty: str | None = None,
+        source: str | None = None,
+        db_path: Any = None,
+    ) -> list[dict[str, Any]]:
+        assert difficulty is None
+        assert source is None
+        assert db_path is None
+        return [_scenario_summary("s1", "easy", "bundled")]
+
+    monkeypatch.setattr(scenarios_api, "list_scenarios", fake_list_scenarios)
+
+    response = await async_client.get("/api/scenarios")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert "scenarios" in payload
+    assert len(payload["scenarios"]) == 1
+    assert payload["scenarios"][0]["id"] == "s1"
+    assert "schema_json" not in payload["scenarios"][0]
+
+
+@pytest.mark.asyncio
+async def test_get_scenarios_forwards_optional_filters(
+    async_client: AsyncClient,
+    monkeypatch: Any,
+) -> None:
+    """difficulty and source query params should be forwarded to service layer."""
+    captured: dict[str, Any] = {}
+
+    def fake_list_scenarios(
+        difficulty: str | None = None,
+        source: str | None = None,
+        db_path: Any = None,
+    ) -> list[dict[str, Any]]:
+        captured["difficulty"] = difficulty
+        captured["source"] = source
+        captured["db_path"] = db_path
+        return [_scenario_summary("s2", "hard", "generated")]
+
+    monkeypatch.setattr(scenarios_api, "list_scenarios", fake_list_scenarios)
+
+    response = await async_client.get("/api/scenarios?difficulty=hard&source=generated")
+
+    assert response.status_code == 200
+    assert captured == {"difficulty": "hard", "source": "generated", "db_path": None}
+    payload = response.json()
+    assert payload["scenarios"][0]["difficulty"] == "hard"
+    assert payload["scenarios"][0]["source"] == "generated"

--- a/specs/001-core-platform/tasks.md
+++ b/specs/001-core-platform/tasks.md
@@ -99,7 +99,7 @@ Tasks below reinforce this by: one function per task where possible, services sp
 
 ### Scenario API
 
-- [ ] T026 [US1] Implement `GET /api/scenarios` endpoint in `backend/src/eduops/api/scenarios.py` — list scenarios with optional `difficulty` and `source` query params, return scenario summaries (excluding schema_json)
+- [x] T026 [US1] Implement `GET /api/scenarios` endpoint in `backend/src/eduops/api/scenarios.py` — list scenarios with optional `difficulty` and `source` query params, return scenario summaries (excluding schema_json)
 - [ ] T027 [US1] Implement `GET /api/scenarios/{scenario_id}` endpoint in `backend/src/eduops/api/scenarios.py` — return scenario detail (excluding schema_json per contract), 404 for unknown IDs
 
 ### Docker Action Executor


### PR DESCRIPTION
## Summary
- Implemented GET /api/scenarios for T026 in backend/src/eduops/api/scenarios.py
- Added optional query params difficulty and source
- Returned contract-shaped scenario summaries via {"scenarios": [...]} 
- Enforced summary-only payload (no schema_json) through strict response models
- Wired router into API registration in backend/src/eduops/api/__init__.py
- Added endpoint tests in backend/tests/test_scenarios_api.py
- Marked T026 complete in specs/001-core-platform/tasks.md

## Issue
Closes #28

## Acceptance Criteria Mapping
- [x] backend/src/eduops/api/scenarios.py created
- [x] GET /api/scenarios endpoint
- [x] Optional difficulty and source query parameters
- [x] Returns scenario summaries excluding schema_json
- [x] Response matches specs/001-core-platform/contracts/api.md

## Implementation Notes
- API remains thin: endpoint delegates data retrieval to eduops.services.catalogue.list_scenarios(...)
- Query parameters are typed literals:
  - difficulty: easy | medium | hard
  - source: bundled | generated
- Response models (ScenarioSummary, ScenarioListResponse) use strict Pydantic config to keep the API contract explicit

## Tests
Executed locally:
- /Users/ren/EDUOPS/eduops/.venv/bin/python -m pytest tests/test_scenarios_api.py tests/test_catalogue_service.py tests/test_db_helpers.py
- Result: 11 passed

## Dependency Context
- T026 depends on T025 (list_scenarios service). This branch is stacked on top of feature/t025-list-get-scenarios-dev so the dependency is present and non-conflicting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a scenarios endpoint to list available scenarios with optional filtering by difficulty (easy, medium, hard) and source (bundled, generated).

* **Tests**
  * Added tests covering the scenarios endpoint, response structure, and query-parameter filtering; verifies returned fields and forwarded filters.

* **Documentation**
  * Marked the scenarios API implementation as complete in project specifications.

* **Chores**
  * App now retains configured database path for request handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->