### PR TITLE
feat: implement execute_setup_actions orchestrator with rollback

### DIFF
--- a/backend/src/eduops/services/docker_exec.py
+++ b/backend/src/eduops/services/docker_exec.py
@@ -8,73 +8,68 @@ from docker.models.images import Image
 from docker.models.networks import Network
 from docker.models.volumes import Volume
 
-# Import the strict models you built in Phase 2
-from eduops.models.scenario import PullImage, BuildImage, CreateNetwork, CreateVolume, RunContainer
+from eduops.models.scenario import PullImage, BuildImage, CreateNetwork, CreateVolume, RunContainer, SetupAction
 
 logger = logging.getLogger(__name__)
 
-# Configurable timeout for blocking Docker operations (5 minutes)
 DEFAULT_DOCKER_TIMEOUT = 300
 
 class DockerExecutionError(Exception):
     """Custom exception raised when a Docker SDK operation fails."""
     pass
 
-def handle_pull_image(client: docker.DockerClient, action: PullImage, session_id: str) -> Image:
-    """Pulls an image from a registry and retags it for session cleanup tracking."""
+def handle_pull_image(client: docker.DockerClient, action: PullImage, session_id: str) -> tuple[Image, bool]:
+    """Pulls an image from a registry. Returns a tuple of (Image, was_new_pull)."""
     logger.info(f"[{session_id}] Pulling image: {action.image}")
     try:
-        image = client.images.pull(action.image)
+        was_new = False
+        try:
+            # Check if we already have it locally
+            image = client.images.get(action.image)
+            logger.debug(f"[{session_id}] Image {action.image} already exists locally.")
+        except ImageNotFound:
+            # We don't have it, so we must pull it
+            was_new = True
+            image = client.images.pull(action.image)
         
-        # Docker SDK doesn't allow labeling pulled images. 
-        # Instead, we apply a session-specific tag so the teardown script can find it.
+        # Apply the session-specific alias tag
         base_name = action.image.split(":")[0]
         session_tag = f"eduops-{session_id}"
-        
         image.tag(repository=base_name, tag=session_tag)
-        logger.debug(f"[{session_id}] Retagged pulled image as {base_name}:{session_tag}")
+        logger.debug(f"[{session_id}] Retagged image as {base_name}:{session_tag}")
         
-        return image
+        return image, was_new
     except (APIError, ImageNotFound) as e:
         logger.error(f"[{session_id}] Failed to pull/tag image {action.image}: {e}")
         raise DockerExecutionError(f"Failed to pull/tag image {action.image}") from e
 
 def handle_build_image(client: docker.DockerClient, action: BuildImage, session_id: str) -> Image:
-    """Builds an image from an in-memory Dockerfile string and logs the output."""
     logger.info(f"[{session_id}] Building image: {action.tag}")
-    
-    # Convert the string content into an in-memory byte stream
     dockerfile_obj = io.BytesIO(action.dockerfile_content.encode("utf-8"))
-    
     try:
         image, build_logs = client.images.build(
             fileobj=dockerfile_obj,
             custom_context=False,
             tag=action.tag,
             labels={"eduops.session": session_id},
-            rm=True,  # Clean up intermediate containers
-            timeout=DEFAULT_DOCKER_TIMEOUT # Circuit breaker for infinite loops
+            rm=True,
+            timeout=DEFAULT_DOCKER_TIMEOUT
         )
-        # Safely iterate through the generator to log the build output
         for chunk in build_logs:
             if "stream" in chunk and chunk["stream"].strip():
                 logger.debug(f"[{session_id}] Build: {chunk['stream'].strip()}")
         return image
-        
     except BuildError as e:
         logger.error(f"[{session_id}] Build failed for {action.tag}")
-        # Print the actual Docker failure reason
         for chunk in e.build_log:
             if "stream" in chunk and chunk["stream"].strip():
                 logger.error(f"[{session_id}] Build log: {chunk['stream'].strip()}")
         raise DockerExecutionError(f"Failed to build image {action.tag}") from e
-        
     except APIError as e:
         logger.error(f"[{session_id}] API error while building {action.tag}: {e}")
         raise DockerExecutionError(f"Failed to build image {action.tag}") from e
 
 def handle_create_network(client: docker.DockerClient, action: CreateNetwork, session_id: str) -> Network:
-    """Creates a Docker network and applies the session label."""
     logger.info(f"[{session_id}] Creating network: {action.name}")
     try:
         return client.networks.create(
@@ -87,7 +82,6 @@ def handle_create_network(client: docker.DockerClient, action: CreateNetwork, se
         raise DockerExecutionError(f"Failed to create network {action.name}") from e
 
 def handle_create_volume(client: docker.DockerClient, action: CreateVolume, session_id: str) -> Volume:
-    """Creates a Docker volume and applies the session label."""
     logger.info(f"[{session_id}] Creating volume: {action.name}")
     try:
         return client.volumes.create(
@@ -99,14 +93,11 @@ def handle_create_volume(client: docker.DockerClient, action: CreateVolume, sess
         raise DockerExecutionError(f"Failed to create volume {action.name}") from e
 
 def handle_run_container(client: docker.DockerClient, action: RunContainer, session_id: str) -> Container:
-    """Runs a Docker container with mapped properties in detached mode."""
     logger.info(f"[{session_id}] Running container from image: {action.image}")
     
-    # 1. Strict validation: Name is mandatory for deterministic cleanup
     if not action.name:
         raise ValueError(f"[{session_id}] Container name is required but was empty or missing.")
 
-    # 2. Mandatory constraints
     kwargs = {
         "image": action.image,
         "name": action.name,
@@ -114,34 +105,17 @@ def handle_run_container(client: docker.DockerClient, action: RunContainer, sess
         "labels": {"eduops.session": session_id},
     }
     
-    # 3. Dynamic {{workspace}} resolution helper
-    workspace_dir = str(Path.home() / ".eduops" / "workspaces" / session_id)
-    
-    def _resolve_workspace(value):
-        if isinstance(value, str):
-            return value.replace("{{workspace}}", workspace_dir)
-        if isinstance(value, list):
-            return [_resolve_workspace(item) for item in value]
-        if isinstance(value, dict):
-            return {_resolve_workspace(k): _resolve_workspace(v) for k, v in value.items()}
-        return value
-
-    # 4. Safely attach optional configurations
+    # Strictly formatted multi-line IF blocks for Ruff compliance (E701 fix)
     if action.ports:
         kwargs["ports"] = action.ports
-        
     if action.volumes:
-        kwargs["volumes"] = _resolve_workspace(action.volumes)
-        
+        kwargs["volumes"] = action.volumes
     if action.network:
         kwargs["network"] = action.network
-        
-    # Fixed typo: reading 'action.env' instead of 'action.environment'
     if action.env:
         kwargs["environment"] = action.env
-        
     if action.command:
-        kwargs["command"] = _resolve_workspace(action.command)
+        kwargs["command"] = action.command
 
     try:
         container = client.containers.run(**kwargs)
@@ -150,3 +124,98 @@ def handle_run_container(client: docker.DockerClient, action: RunContainer, sess
     except (ContainerError, ImageNotFound, APIError) as e:
         logger.error(f"[{session_id}] Failed to run container {action.name}: {e}")
         raise DockerExecutionError(f"Failed to run container {action.name}") from e
+
+def execute_setup_actions(client: docker.DockerClient, actions: list[SetupAction], session_id: str) -> None:
+    logger.info(f"[{session_id}] Executing {len(actions)} setup actions...")
+    created_resources = []
+    
+    # Fixed trailing slash requirement
+    workspace_dir = str(Path.home() / ".eduops" / "workspaces" / session_id) + "/"
+
+    def _resolve_workspace_strings(data):
+        if isinstance(data, str):
+            return data.replace("{{workspace}}", workspace_dir)
+        if isinstance(data, list):
+            return [_resolve_workspace_strings(item) for item in data]
+        if isinstance(data, dict):
+            # Strict dict key/value resolution
+            return {
+                _resolve_workspace_strings(k) if isinstance(k, str) else k:
+                _resolve_workspace_strings(v)
+                for k, v in data.items()
+            }
+        return data
+
+    try:
+        for action in actions:
+            action_dict = action.model_dump()
+            resolved_dict = _resolve_workspace_strings(action_dict)
+            resolved_action = action.__class__.model_validate(resolved_dict)
+            action_type = resolved_action.action
+            
+            if action_type == "pull_image":
+                img, was_new = handle_pull_image(client, resolved_action, session_id)
+                session_tag = f"{resolved_action.image.split(':')[0]}:eduops-{session_id}"
+                created_resources.append(("image", session_tag))
+                if was_new:
+                    # If we downloaded it fresh, mark the original for deletion too!
+                    created_resources.append(("image", resolved_action.image))
+                
+            elif action_type == "build_image":
+                img = handle_build_image(client, resolved_action, session_id)
+                created_resources.append(("image", img.id))
+                
+            elif action_type == "create_network":
+                net = handle_create_network(client, resolved_action, session_id)
+                created_resources.append(("network", net.id))
+                
+            elif action_type == "create_volume":
+                vol = handle_create_volume(client, resolved_action, session_id)
+                created_resources.append(("volume", vol.id))
+                
+            elif action_type == "run_container":
+                cont = handle_run_container(client, resolved_action, session_id)
+                created_resources.append(("container", cont.id))
+                
+            else:
+                raise DockerExecutionError(f"Unknown setup action type: {action_type}")
+                
+        logger.info(f"[{session_id}] Successfully executed all {len(actions)} setup actions.")
+        
+    except Exception as e:
+        logger.error(f"[{session_id}] Setup failed: {e}. Initiating rollback...")
+        _rollback_resources(client, created_resources, session_id)
+        raise DockerExecutionError(f"Setup failed, resources rolled back: {e}") from e
+
+def _rollback_resources(client: docker.DockerClient, resources: list[tuple[str, str]], session_id: str) -> None:
+    """Reverses the creation of Docker resources (LIFO), then performs an aggressive label sweep."""
+    
+    # 1. Standard LIFO Rollback
+    for res_type, res_id in reversed(resources):
+        logger.info(f"[{session_id}] Rolling back {res_type} {res_id}...")
+        try:
+            if res_type == "container":
+                client.containers.get(res_id).remove(force=True, v=True)
+            elif res_type == "network":
+                client.networks.get(res_id).remove()
+            elif res_type == "volume":
+                client.volumes.get(res_id).remove()
+            elif res_type == "image":
+                client.images.remove(image=res_id, force=True)
+        except Exception as cleanup_err:
+            logger.error(f"[{session_id}] Failed to rollback {res_type} {res_id}: {cleanup_err}")
+
+    # 2. Aggressive Label Sweep (CodeRabbit constraint)
+    logger.info(f"[{session_id}] Performing aggressive label sweep for stranded resources...")
+    filters = {"label": f"eduops.session={session_id}"}
+    try:
+        for c in client.containers.list(all=True, filters=filters):
+            c.remove(force=True, v=True)
+        for n in client.networks.list(filters=filters):
+            n.remove()
+        for v in client.volumes.list(filters=filters):
+            v.remove()
+        for i in client.images.list(filters=filters):
+            client.images.remove(image=i.id, force=True)
+    except Exception as sweep_err:
+        logger.error(f"[{session_id}] Label sweep rollback error: {sweep_err}")


### PR DESCRIPTION
### Description
This PR fulfills Task T030 by implementing the master `execute_setup_actions()` orchestrator, bringing together all the handlers developed in T028 and T029.

**Changes Included:**
* Implemented `execute_setup_actions()` to iterate through the typed `SetupAction` union.
* Extracted the `{{workspace}}` translation logic from `handle_run_container` and moved it into the orchestrator using `_resolve_workspace_strings()`. This ensures the template variable is securely replaced across *all* action types (including Dockerfile contents and environment variables) before being dispatched.
* Built a dispatch switch statement to route actions to their respective handlers.
* Implemented robust state tracking: as resources are created, their IDs and types are appended to a `created_resources` list.
* Implemented `_rollback_resources()`, which catches any execution failure and removes all tracked resources in LIFO order (Last In, First Out) to prevent dangling containers or networks on a failed setup.

### Resolves
Fixes #30

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated resource cleanup and rollback when Docker operations fail, ensuring failed setup attempts don't leave dangling resources
  * Enhanced setup action execution with dynamic workspace path templating across configuration

* **Improvements**
  * Streamlined container execution logic for better performance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->